### PR TITLE
Replace PNG assets with SVG wireframes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx,js,jsx,json,yml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json']
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'airbnb',
+    'airbnb/hooks',
+    'airbnb-typescript'
+  ],
+  rules: {
+    'react/react-in-jsx-scope': 'off'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,48 +1,10 @@
-# Wordpress - ignore core, configuration, examples, uploads and logs.
-# https://github.com/github/gitignore/blob/main/WordPress.gitignore
-
-# Core
-#
-# Note: if you want to stage/commit WP core files
-# you can delete this whole section/until Configuration.
-/wp-admin/
-/wp-content/index.php
-/wp-content/languages
-/wp-content/plugins/index.php
-/wp-content/themes/index.php
-/wp-includes/
-/index.php
-/license.txt
-/readme.html
-/wp-*.php
-/xmlrpc.php
-
-# Configuration
-wp-config.php
-
-# Example themes
-/wp-content/themes/twenty*/
-
-# Example plugin
-/wp-content/plugins/hello.php
-
-# Uploads
-/wp-content/uploads/
-
-# Log files
-*.log
-
-# htaccess
-/.htaccess
-
-# All plugins
-#
-# Note: If you wish to whitelist plugins,
-# uncomment the next line
-#/wp-content/plugins
-
-# All themes
-#
-# Note: If you wish to whitelist themes,
-# uncomment the next line
-#/wp-content/themes
+/vendor/
+/node_modules/
+/dist/
+/build/
+.DS_Store
+/.idea/
+/.vscode/
+.env
+composer.lock
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-06-01
+### Added
+- Dispo board with week/day view, delivery note import dialog and blocker overlay.
+- CalDAV event sync that reflects status emojis in titles and keeps structured notes.
+- Mobile job sheet PWA with magic links, “My jobs today” list and offline ✅ Done queue.
+- Payment sync that marks jobs as 💰 when linked invoices are paid.
+- Admin settings UI, documentation set, mockups and API Postman collection.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners for the SG Jobs plugin repository
+* @sgops/engineering
+
+# Frontend assets
+/src/Ui/Board/assets/ @sgops/frontend
+/src/Ui/JobSheet/assets/ @sgops/frontend
+
+# Infrastructure integrations
+/src/Infra/ @sgops/platform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to SG Jobs
+
+Thank you for investing time in improving SG Jobs. The plugin orchestrates several external systems and we rely on deterministic processes to keep deployments safe.
+
+## Development workflow
+
+1. Fork the repository and clone your fork.
+2. Install dependencies via `composer install` and `npm install`.
+3. Copy `config/example.env` to `.env` and adjust the credentials for your sandbox services.
+4. Run `npm run dev` to watch the React board and PWA bundles while developing.
+5. Run `composer analyse` and `npm run typecheck` before opening a pull request.
+6. Document behaviour changes in `CHANGELOG.md` under the **Unreleased** section.
+
+## Coding standards
+
+- PHP must follow PSR-12 and pass PHPStan level 7 checks.
+- TypeScript follows the Airbnb + React rule set. Prefer functional components.
+- Avoid direct `var_dump`, use the logger instead.
+- Handle exceptions and propagate meaningful WP_Error objects from REST controllers.
+
+## Commit messages
+
+Use present tense and include the scope, e.g. `Add CalDAV retry backoff`. Reference Jira tickets where applicable.
+
+## Security
+
+The repository contains integration code for bexio and CalDAV. Never hardcode credentials. When sharing logs or screenshots, redact tokens and customer data.
+
+## Reporting issues
+
+Create a GitHub issue that includes reproduction steps, expected vs actual outcome and relevant logs. Attach screenshots or HAR files when the bug relates to the board or PWA.
+
+We appreciate every contribution that helps installers complete jobs faster!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SG Operations
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# sg-jobs
+# SG Jobs WordPress Plugin
+
+SG Jobs bridges bexio delivery notes with a scheduling cockpit and mobile job execution. Disposition keeps working inside WordPress and Apple Calendar while installers receive magic links that open a mobile job sheet PWA. Every status update synchronises to CalDAV calendars so the office, the field team and Apple Calendar stay aligned.
+
+## Key features
+
+- **Dispo board** with React/FullCalendar week and day views, blocker overlay and live delivery note import.
+- **Job Sheet PWA** for installers without WordPress accounts using short-lived JWT magic links.
+- **CalDAV sync** that mirrors status emojis 🔴/✅/🧾/💰 in team calendars while keeping structured notes consistent.
+- **Live bexio reads** with retry/backoff, Action Scheduler queues and audit logging for every state change.
+- **Payment sync** that marks jobs 💰 when the linked bexio invoice has been paid.
+
+## Getting started
+
+### 1. Install dependencies
+
+```bash
+composer install
+npm install
+npm run build
+```
+
+### 2. Configure environment
+
+Copy `config/example.env` to `.env` and provide production credentials. Keys must match the WordPress settings page.
+
+### 3. Activate the plugin
+
+Upload the plugin folder to `wp-content/plugins`, then activate **SG Jobs** in the WordPress admin. During activation database tables are created and required cron hooks are registered.
+
+### 4. Configure settings
+
+Navigate to **Settings → SG Jobs** and enter:
+
+- bexio base URL and API token.
+- CalDAV base URL, username and password for the service account.
+- Team definitions with CalDAV principal, execution calendar path and blocker calendar path.
+- JWT secret (32+ chars) and expiry days for magic links.
+
+### 5. Place shortcodes
+
+Add the shortcodes to appropriate WordPress pages:
+
+- `[sg_jobs_board]` for the disposition board (requires the `sgjobs_manage` capability).
+- `[sg_jobs_mine]` for the “My jobs today” PWA view (restricted to users with a team magic link).
+
+### 6. Enable cron jobs
+
+Ensure WordPress cron or a system cron triggers `wp cron event run sg_jobs_bexio_payment_sync` at least every 15 minutes. Optional: schedule the CalDAV watcher if external calendar edits must be reconciled.
+
+### 7. Connect Apple Calendar
+
+Subscribe to each team execution calendar and its blocker calendar in Apple Calendar. Jobs will show the emoji status in the title and the structured notes block in the description.
+
+## Security notes
+
+- Magic link JWTs are signed server-side only and scoped to job or team access.
+- All REST endpoints validate capabilities or JWT scopes and enforce idempotency via the `Idempotency-Key` header.
+- No API secrets are ever exposed to the browser bundle; the client communicates with WordPress REST endpoints exclusively.
+
+## Acceptance checklist
+
+- Installer can mark ✅ within ten seconds from opening the job sheet.
+- Disposition sees updates immediately in the board and Apple Calendar.
+- Phone numbers are taken strictly from the delivery note or must be supplied manually when missing.
+- All positions of a delivery note are displayed on the job sheet and board preview without filtering.
+
+## Screenshots & mockups
+
+Mockups illustrating the primary workflows are available in [`docs/mockups`](docs/mockups):
+
+- Dispo board week view with blocker overlay (`board-week.svg`).
+- Apple Calendar event layout with emoji status (`apple-calendar.svg`).
+- Mobile job sheet with phones, address, positions and ✅ action (`jobsheet-mobile.svg`).
+
+## Roadmap
+
+- Public online booking requests with calendar availability validation.
+- File uploads and customer signatures via Nextcloud signed URLs.
+- Optional CalDAV hard-lock plugin to prevent out-of-window edits.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "sg/jobs",
+  "description": "WordPress plugin that connects bexio delivery notes with a scheduling board, CalDAV calendars and installer job sheets.",
+  "type": "wordpress-plugin",
+  "license": "MIT",
+  "require": {
+    "php": "^8.2",
+    "guzzlehttp/guzzle": "^7.8",
+    "firebase/php-jwt": "^6.10",
+    "johnbillion/extended-cpts": "^5.0"
+  },
+  "require-dev": {
+    "phpstan/phpstan": "^1.11",
+    "squizlabs/php_codesniffer": "^3.9",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "SGJobs\\": "src/"
+    }
+  },
+  "scripts": {
+    "analyse": "phpstan analyse src",
+    "cs": "phpcs --standard=PSR12 src",
+    "fix": "phpcbf --standard=PSR12 src"
+  }
+}

--- a/config/example.env
+++ b/config/example.env
@@ -1,0 +1,8 @@
+BEXIO_BASE_URL=https://api.bexio.com/2.0
+BEXIO_API_TOKEN=replace-with-sandbox-token
+CALDAV_BASE_URL=https://nextcloud.example.com/remote.php/dav
+CALDAV_USER=service-account
+CALDAV_PASS=service-password
+JWT_SECRET=change-me-32chars-minimum
+JWT_EXPIRE_DAYS=14
+TZ=Europe/Zurich

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,87 @@
+# API Contract
+
+Base URL: `/wp-json/sgjobs/v1`
+
+## Authentication
+
+- **Dispo/Admin**: WordPress login with capability `sgjobs_manage`.
+- **Installer**: `Authorization: Bearer <MagicJWT>` created by `JwtService`.
+
+## Endpoints
+
+### `POST /jobs`
+
+Creates a job by importing a bexio delivery note.
+
+Request body:
+```json
+{
+  "delivery_note_nr": "5009",
+  "team_id": 1,
+  "starts_at": "2025-10-07T08:00:00+02:00",
+  "ends_at": "2025-10-07T10:00:00+02:00",
+  "location_city": "Zürich",
+  "notes": "Hintereingang, 3. OG",
+  "phones": ["+41 79 123 45 67"]
+}
+```
+Response 201:
+```json
+{
+  "job_id": 42,
+  "public_job_url": "https://example.com/jobs/<token>",
+  "caldav_event_uid": "sgjobs-42-evt64f..."
+}
+```
+Errors: `400` missing phone, `404` delivery note missing, `409` idempotency violation.
+
+### `GET /jobs?team_id=&date=`
+
+Returns jobs and blockers for the board. Response contains `jobs` and `blockers` arrays.
+
+### `GET /jobs/{id}`
+
+Returns job details including positions, phones and structured address. Installer tokens and Dispo can access.
+
+### `POST /jobs/{id}/done`
+
+Marks a job as done. Installer only.
+
+Request body:
+```json
+{ "comment": "Serien: QK-123456" }
+```
+Response:
+```json
+{ "status": "done" }
+```
+
+### `POST /jobs/{id}/billable`
+
+Marks a job as billable. Requires Dispo capability.
+
+Response:
+```json
+{ "status": "billable" }
+```
+
+### `POST /sync/bexio-payments`
+
+Webhook/cron endpoint that triggers payment sync. Protected by application password or WP cron.
+
+## Errors
+
+Errors follow the structure:
+```json
+{
+  "error": {
+    "code": "sg_jobs_delivery_note_missing",
+    "message": "Delivery note not found in bexio."
+  },
+  "retry_after": 15
+}
+```
+
+## Idempotency
+
+Write endpoints accept an `Idempotency-Key` header. Responses for duplicate keys are served from cache with HTTP 200.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,81 @@
+# Data Model
+
+## Tables
+
+### `wp_sg_jobs`
+
+Stores job metadata sourced from bexio delivery notes.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `id` | BIGINT | Primary key |
+| `delivery_note_id` | BIGINT | bexio identifier |
+| `delivery_note_nr` | VARCHAR(64) | search key |
+| `sales_order_nr` | VARCHAR(64) | optional reference |
+| `team_id` | BIGINT | FK → `wp_sg_teams.id` |
+| `starts_at`, `ends_at` | DATETIME UTC | scheduled slot |
+| `tz` | VARCHAR | original timezone |
+| `location_city` | VARCHAR | used in calendar title |
+| `address_line` | TEXT | formatted street |
+| `phones_json` | LONGTEXT | JSON array from delivery note or manual input |
+| `status` | ENUM | `open`, `done`, `billable`, `paid` |
+| `caldav_event_uid` | VARCHAR | VEVENT UID |
+| `job_token_hash` | VARCHAR | sha256 of magic link token |
+| `notes` | TEXT | installer/office notes |
+| `created_by`, `updated_by` | BIGINT | WP user IDs |
+| `created_at`, `updated_at` | DATETIME | audit |
+
+### `wp_sg_job_positions`
+
+All delivery note positions without filtering.
+
+| Column | Type |
+| ------ | ---- |
+| `job_id` | FK |
+| `bexio_position_id` | BIGINT |
+| `article_no` | VARCHAR |
+| `title` | VARCHAR |
+| `description` | TEXT |
+| `qty` | DECIMAL |
+| `unit` | VARCHAR |
+| `work_type` | ENUM |
+| `sort` | INT |
+
+### `wp_sg_teams`
+
+Defines the CalDAV integration for each crew.
+
+| Column | Notes |
+| ------ | ----- |
+| `name` | Display name |
+| `caldav_principal` | Nextcloud principal identifier |
+| `team_calendar_path` | Full CalDAV collection URL |
+| `blocker_calendar_path` | Gray overlay calendar |
+
+### `wp_sg_users_teams`
+
+Future mapping between WP users and teams for board filtering.
+
+### `wp_sg_job_audit`
+
+Immutable audit trail of actions performed on jobs.
+
+| Column | Notes |
+| ------ | ----- |
+| `actor` | User ID or magic link subject |
+| `action` | Status change or webhook |
+| `payload_json` | Additional metadata |
+| `created_at` | Timestamp |
+
+## Relationships
+
+- `sg_job_positions.job_id` → `sg_jobs.id`
+- `sg_jobs.team_id` → `sg_teams.id`
+- `sg_job_audit.job_id` → `sg_jobs.id`
+- `sg_users_teams.team_id` → `sg_teams.id`
+
+## Indexing
+
+- Delivery note number and CalDAV UID for fast lookups.
+- Composite PK on `sg_users_teams` for uniqueness.
+- Foreign keys maintain referential integrity for cascading deletes.

--- a/docs/examples/event-description-template.txt
+++ b/docs/examples/event-description-template.txt
@@ -1,0 +1,8 @@
+LieferscheinNr: {delivery_note_nr}
+AuftragNr: {sales_order_nr or -}
+Kunde: {customer_name}
+Telefon: {phone1; phone2; ...}
+Adresse: {address_line}
+Hinweise: {notes}
+Job-URL: {public_job_url}
+Status: {status}

--- a/docs/examples/postman_collection.json
+++ b/docs/examples/postman_collection.json
@@ -1,0 +1,45 @@
+{
+  "info": {
+    "name": "SG Jobs API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Create job",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/wp-json/sgjobs/v1/jobs",
+          "host": ["{{baseUrl}}"],
+          "path": ["wp-json", "sgjobs", "v1", "jobs"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"delivery_note_nr\": \"5009\",\n  \"team_id\": 1,\n  \"starts_at\": \"2025-10-07T08:00:00+02:00\",\n  \"ends_at\": \"2025-10-07T10:00:00+02:00\",\n  \"location_city\": \"Zürich\"\n}"
+        }
+      }
+    },
+    {
+      "name": "Mark job done",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Authorization", "value": "Bearer {{installerToken}}" }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/wp-json/sgjobs/v1/jobs/42/done",
+          "host": ["{{baseUrl}}"],
+          "path": ["wp-json", "sgjobs", "v1", "jobs", "42", "done"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"comment\": \"Serien: QK-123456\"\n}"
+        }
+      }
+    }
+  ]
+}

--- a/docs/examples/sample-delivery-note.json
+++ b/docs/examples/sample-delivery-note.json
@@ -1,0 +1,32 @@
+{
+  "id": 7810,
+  "document_nr": "5009",
+  "contact_name": "Elektro Müller AG",
+  "delivery_address": {
+    "address_line1": "Badenerstrasse 21",
+    "zip": "8004",
+    "city": "Zürich",
+    "country": "Schweiz",
+    "phone": "+41 44 111 22 33",
+    "mobile": null
+  },
+  "positions": [
+    {
+      "id": 2001,
+      "article_nr": "KT-42",
+      "text": "Klimagerät Inneneinheit",
+      "description": "Montage gemäss Offerte",
+      "amount": 1,
+      "unit_name": "Stk"
+    },
+    {
+      "id": 2002,
+      "article_nr": "KT-43",
+      "text": "Kupferleitung",
+      "description": "5m Rolle",
+      "amount": 1.5,
+      "unit_name": "m"
+    }
+  ],
+  "reference": "SO-42015"
+}

--- a/docs/mockups/apple-calendar.svg
+++ b/docs/mockups/apple-calendar.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 540" role="img" aria-labelledby="title desc">
+  <title id="title">Apple Calendar Wireframe</title>
+  <desc id="desc">Daily agenda showing a synced job event with emoji in the title and structured notes snippet.</desc>
+  <rect width="720" height="540" fill="#f1f5f9"/>
+  <rect x="48" y="40" width="624" height="64" fill="#0f172a" rx="16"/>
+  <text x="80" y="80" font-family="SF Pro Display,Arial,sans-serif" font-size="28" fill="#ffffff">Dienstag 7. Oktober</text>
+  <rect x="48" y="124" width="624" height="96" fill="#ffffff" stroke="#94a3b8" stroke-width="2" rx="18"/>
+  <text x="72" y="160" font-family="SF Pro Text,Arial,sans-serif" font-size="26" fill="#0f172a">🔴 Zürich | 5009 | Küng AG</text>
+  <text x="72" y="192" font-family="SF Pro Text,Arial,sans-serif" font-size="18" fill="#475569">Ort · Zürich</text>
+  <rect x="48" y="236" width="624" height="200" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" rx="18"/>
+  <text x="72" y="272" font-family="SF Pro Text,Arial,sans-serif" font-size="20" fill="#0f172a">Notizen</text>
+  <text x="72" y="304" font-family="SF Mono,Consolas,monospace" font-size="16" fill="#1e293b">LieferscheinNr: 5009</text>
+  <text x="72" y="328" font-family="SF Mono,Consolas,monospace" font-size="16" fill="#1e293b">AuftragNr: -</text>
+  <text x="72" y="352" font-family="SF Mono,Consolas,monospace" font-size="16" fill="#1e293b">Kunde: Küng AG</text>
+  <text x="72" y="376" font-family="SF Mono,Consolas,monospace" font-size="16" fill="#1e293b">Telefon: +41 79 123 45 67</text>
+  <text x="72" y="400" font-family="SF Mono,Consolas,monospace" font-size="16" fill="#1e293b">Job-URL: https://example.tld/jobs/abc</text>
+  <rect x="48" y="460" width="624" height="52" fill="#e2e8f0" rx="12"/>
+  <text x="72" y="492" font-family="SF Pro Text,Arial,sans-serif" font-size="18" fill="#1e293b">Blocker Kalender · grau hinterlegt</text>
+</svg>

--- a/docs/mockups/board-week.svg
+++ b/docs/mockups/board-week.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Dispo Board Wireframe</title>
+  <desc id="desc">Week calendar view with team filters, blocker overlay and job cards with emoji statuses.</desc>
+  <rect width="960" height="540" fill="#f8fafc"/>
+  <rect x="32" y="32" width="896" height="64" fill="#0f172a" rx="8"/>
+  <text x="64" y="72" font-family="Arial,Helvetica,sans-serif" font-size="28" fill="#f8fafc">Dispo Board · Woche 18</text>
+  <rect x="32" y="120" width="160" height="320" fill="#e2e8f0" rx="12"/>
+  <text x="56" y="160" font-family="Arial,Helvetica,sans-serif" font-size="20" fill="#0f172a">Teams</text>
+  <text x="56" y="196" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#1e293b">Team Alpha</text>
+  <text x="56" y="228" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#1e293b">Team Beta</text>
+  <rect x="216" y="120" width="712" height="320" fill="#cbd5f5" opacity="0.35"/>
+  <g fill="#94a3b8" opacity="0.8">
+    <rect x="216" y="120" width="712" height="40"/>
+    <rect x="216" y="200" width="712" height="40"/>
+    <rect x="216" y="280" width="712" height="40"/>
+    <rect x="216" y="360" width="712" height="40"/>
+  </g>
+  <rect x="248" y="168" width="176" height="88" fill="#ffffff" stroke="#334155" stroke-width="2" rx="10"/>
+  <text x="264" y="196" font-family="Arial,Helvetica,sans-serif" font-size="22" fill="#0f172a">🔴 Zürich</text>
+  <text x="264" y="224" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#1e293b">LS 5009 · Küng AG</text>
+  <rect x="456" y="264" width="176" height="88" fill="#ffffff" stroke="#15803d" stroke-width="2" rx="10"/>
+  <text x="472" y="292" font-family="Arial,Helvetica,sans-serif" font-size="22" fill="#166534">✅ Bern</text>
+  <text x="472" y="320" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#166534">LS 5012 · Haller GmbH</text>
+  <rect x="664" y="200" width="176" height="88" fill="#ffffff" stroke="#b45309" stroke-width="2" rx="10"/>
+  <text x="680" y="228" font-family="Arial,Helvetica,sans-serif" font-size="22" fill="#b45309">🧾 Basel</text>
+  <text x="680" y="256" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#b45309">LS 5016 · Studio Seeblick</text>
+  <rect x="32" y="464" width="896" height="44" fill="#e2e8f0" rx="8"/>
+  <text x="48" y="492" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#1e293b">Suche · Lieferschein 5009</text>
+</svg>

--- a/docs/mockups/jobsheet-mobile.svg
+++ b/docs/mockups/jobsheet-mobile.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" role="img" aria-labelledby="title desc">
+  <title id="title">Job Sheet PWA Wireframe</title>
+  <desc id="desc">Mobile job sheet showing customer details, phone buttons, address, positions and a large done action.</desc>
+  <rect width="360" height="720" fill="#0f172a" rx="36"/>
+  <rect x="12" y="24" width="336" height="672" fill="#f8fafc" rx="28"/>
+  <text x="72" y="96" font-family="Arial,Helvetica,sans-serif" font-size="26" fill="#0f172a">🔴 Lieferschein 5009</text>
+  <text x="36" y="138" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#1e293b">Küng AG · Zürich</text>
+  <rect x="36" y="160" width="288" height="44" fill="#0ea5e9" rx="12"/>
+  <text x="56" y="188" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#ffffff">📞 +41 79 123 45 67</text>
+  <rect x="36" y="212" width="288" height="44" fill="#0ea5e9" rx="12"/>
+  <text x="56" y="240" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#ffffff">📞 +41 43 555 77 22</text>
+  <rect x="36" y="272" width="288" height="64" fill="#e2e8f0" rx="16"/>
+  <text x="56" y="300" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#1e293b">Adresse: Lagerstrasse 12, Zürich</text>
+  <rect x="36" y="352" width="288" height="160" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" rx="16"/>
+  <text x="56" y="384" font-family="Arial,Helvetica,sans-serif" font-size="18" fill="#0f172a">Positionen</text>
+  <text x="56" y="416" font-family="Arial,Helvetica,sans-serif" font-size="14" fill="#334155">· Montage Wärmepumpe</text>
+  <text x="56" y="444" font-family="Arial,Helvetica,sans-serif" font-size="14" fill="#334155">· Leitungsprüfung</text>
+  <rect x="36" y="528" width="288" height="72" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" rx="16"/>
+  <text x="56" y="560" font-family="Arial,Helvetica,sans-serif" font-size="16" fill="#0f172a">Kommentar (Seriennummer)</text>
+  <rect x="72" y="624" width="216" height="64" fill="#22c55e" rx="32"/>
+  <text x="120" y="666" font-family="Arial,Helvetica,sans-serif" font-size="26" fill="#ffffff">✅ Fertig</text>
+</svg>

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,41 @@
+# Security Model
+
+## Authentication flows
+
+- **Disposition/Admin** authenticate with standard WordPress credentials and must have capability `sgjobs_manage`.
+- **Installers** receive magic links encoded as JWT. Tokens contain claims `sub` (job or team scope), `exp`, `nonce` and optional `team_id`.
+- Magic links are single URL endpoints served via HTTPS only and hashed server side (`job_token_hash`).
+
+## Authorization
+
+- Board endpoints require `sgjobs_manage`.
+- Job sheet endpoints validate the JWT and restrict actions to the scoped job or team.
+- Team scoped tokens can fetch `/my-jobs` for a given date; job scoped tokens can only load and complete one job.
+
+## JWT settings
+
+- Algorithm: HS256 with 32+ character secret stored server-side only.
+- Default expiry: 14 days.
+- Device binding optional: the first open stores a device token and subsequent requests ask for a 4-digit PIN (out of scope for initial release but interface ready).
+
+## Data protection
+
+- Phone numbers are never fetched from sales orders; they come directly from the delivery note or manual input.
+- Secrets (bexio token, CalDAV credentials, JWT secret) live in `.env` / WP options and are never exposed in frontend bundles.
+- Audit log tracks `actor`, `action` and payload metadata without persisting secrets or raw tokens.
+
+## Transport security
+
+- All endpoints must be served via HTTPS. Service worker refuses to install on insecure origins.
+- CalDAV credentials belong to a service account with least privilege access only to team calendars.
+
+## Logging
+
+- Logger redacts tokens before writing to PHP error log.
+- Debug logging is disabled unless `WP_DEBUG` is true. Production logs use Action Scheduler hooks for failure reporting.
+
+## Threat considerations
+
+- Replay of magic link tokens is mitigated by expiration and optional device binding.
+- REST write endpoints use idempotency keys to avoid duplicate CalDAV events on retries.
+- Rate limits from bexio are handled with exponential backoff to prevent bans.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,0 +1,45 @@
+# System Architecture
+
+SG Jobs orchestrates bexio, WordPress and Nextcloud to provide a unified installation workflow.
+
+## Components
+
+- **WordPress plugin**: Hosts REST API, queues and UI shortcodes.
+- **bexio API**: Provides delivery notes and invoice payment status.
+- **Nextcloud CalDAV**: Stores team and blocker calendars that sync to Apple Calendar.
+- **Magic link PWA**: Served from WordPress and authenticated using JWT.
+
+## Sequence: Delivery note → Job
+
+1. Dispo selects “Import from bexio” in the board.
+2. WordPress calls `BexioService.getDeliveryNoteByNumber` and loads all positions.
+3. Job data is stored in the `sg_jobs` tables and a magic link JWT is generated.
+4. `CalendarService.createOrUpdateEvent` writes a VEVENT via CalDAV with the structured notes block.
+5. Apple Calendar receives the change and renders the 🔴 job.
+
+## Sequence: Installer marks ✅
+
+1. Installer opens the magic link, the JWT is validated server side.
+2. `JobsService.markDone` updates the job status and stores the installer comment.
+3. `CalendarService.createOrUpdateEvent` rewrites the VEVENT with a ✅ title and updated description block.
+4. Action Scheduler queue retries CalDAV writes if the server responds with a transient failure.
+5. Apple Calendar shows the updated emoji immediately.
+
+## Sequence: Payment sync → 💰
+
+1. Cron fires `sg_jobs_bexio_payment_sync` every 15 minutes.
+2. `BexioPaymentSync` checks billable jobs against bexio invoices.
+3. Paid invoices trigger `JobsService.markPaid` which updates the job and CalDAV event.
+4. Apple Calendar reflects 💰 and the audit log stores the automated action.
+
+## Data stores
+
+- WordPress database tables `sg_jobs*` for job metadata and audit trail.
+- CalDAV collections for team execution and blocker calendars.
+- Action Scheduler tables for asynchronous tasks.
+
+## Integration resilience
+
+- Exponential backoff and respect for `Retry-After` headers on bexio requests.
+- CalDAV writes are idempotent; the VEVENT UID is stored in the job table.
+- REST API write endpoints support an `Idempotency-Key` header to deduplicate retries from the board and PWA.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "sg-jobs",
+  "version": "0.1.0",
+  "description": "Build tooling for the SG Jobs WordPress plugin (board React UI and PWA job sheet).",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint 'src/**/*.ts*' 'public/**/*.js'",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/wordpress__block-editor": "^12.0.0",
+    "@types/wordpress__data": "^9.0.0",
+    "@types/node": "^20.11.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "eslint": "^8.56.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@tsconfig/recommended": "^1.0.5"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "dayjs": "^1.11.10",
+    "fullcalendar": "^6.1.10",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/public/board/index.php
+++ b/public/board/index.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SG Jobs Disposition</title>
+    <link rel="stylesheet" href="/wp-content/plugins/sg-jobs/dist/board.css">
+</head>
+<body>
+<div id="sg-jobs-board">Lade Disposition…</div>
+<script src="/wp-content/plugins/sg-jobs/dist/board.js" type="module"></script>
+</body>
+</html>

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#0f172a"/>
+  <text x="50%" y="52%" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="88" fill="#38bdf8">SG</text>
+  <circle cx="152" cy="40" r="18" fill="#22c55e"/>
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#0f172a"/>
+  <text x="50%" y="52%" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-size="224" fill="#38bdf8">SG</text>
+  <circle cx="416" cy="112" r="48" fill="#facc15"/>
+</svg>

--- a/public/jobs/index.php
+++ b/public/jobs/index.php
@@ -1,0 +1,16 @@
+<?php
+/** @var string $token */
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SG Jobs Einsatz</title>
+    <link rel="manifest" href="/wp-content/plugins/sg-jobs/public/manifest.webmanifest">
+    <link rel="stylesheet" href="/wp-content/plugins/sg-jobs/dist/jobsheet.css">
+</head>
+<body>
+<div id="sg-jobs-sheet">Lade...</div>
+<script src="/wp-content/plugins/sg-jobs/dist/jobsheet.js" type="module"></script>
+</body>
+</html>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "SG Jobs Einsatz",
+  "short_name": "SG Jobs",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f172a",
+  "icons": [
+    { "src": "/wp-content/plugins/sg-jobs/public/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "/wp-content/plugins/sg-jobs/public/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,40 @@
+const VERSION = 'sgjobs-sw-v1';
+const STATIC_CACHE = `${VERSION}-static`;
+const OFFLINE_URLS = [
+  '/wp-content/plugins/sg-jobs/dist/jobsheet.js',
+  '/wp-content/plugins/sg-jobs/dist/jobsheet.css'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(OFFLINE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((key) => !key.startsWith(VERSION)).map((key) => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  if (request.url.includes('/wp-json/sgjobs/v1/jobs/') && request.method === 'POST') {
+    event.respondWith(fetch(request));
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => cached || fetch(request).then((response) => {
+      const copy = response.clone();
+      caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
+      return response;
+    }))
+  );
+});

--- a/sg-jobs.php
+++ b/sg-jobs.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: SG Jobs
+ * Description: Integrates bexio delivery notes with a scheduling board, CalDAV sync and job sheets for installers.
+ * Requires at least: 6.5
+ * Requires PHP: 8.2
+ * Version: 0.1.0
+ * Author: SG Operations
+ * Text Domain: sg-jobs
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+if (! defined('SGJOBS_PLUGIN_FILE')) {
+    define('SGJOBS_PLUGIN_FILE', __FILE__);
+}
+
+use SGJobs\Bootstrap;
+
+$bootstrap = Bootstrap::instance();
+$bootstrap->init();

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Admin;
+
+class SettingsPage
+{
+    public function register(): void
+    {
+        add_action('admin_menu', [$this, 'addMenu']);
+        add_action('admin_init', [$this, 'registerSettings']);
+    }
+
+    public function addMenu(): void
+    {
+        add_options_page(
+            __('SG Jobs Settings', 'sg-jobs'),
+            __('SG Jobs', 'sg-jobs'),
+            'manage_options',
+            'sg-jobs',
+            [$this, 'renderPage']
+        );
+    }
+
+    public function registerSettings(): void
+    {
+        register_setting('sg_jobs', 'sg_jobs_bexio', ['sanitize_callback' => [$this, 'sanitizeArray']]);
+        register_setting('sg_jobs', 'sg_jobs_caldav', ['sanitize_callback' => [$this, 'sanitizeArray']]);
+        register_setting('sg_jobs', 'sg_jobs_jwt', ['sanitize_callback' => [$this, 'sanitizeArray']]);
+        register_setting('sg_jobs', 'sg_jobs_teams', ['sanitize_callback' => [$this, 'sanitizeTeams']]);
+
+        add_settings_section('sg_jobs_bexio_section', __('bexio', 'sg-jobs'), function (): void {
+            echo '<p>' . esc_html__('Configure the bexio API connection. Delivery notes are fetched live.', 'sg-jobs') . '</p>';
+        }, 'sg-jobs');
+
+        add_settings_field('sg_jobs_bexio_base', __('Base URL', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_bexio', []);
+            $value = esc_attr($options['base_url'] ?? '');
+            echo '<input type="url" name="sg_jobs_bexio[base_url]" value="' . $value . '" class="regular-text" required />';
+        }, 'sg-jobs', 'sg_jobs_bexio_section');
+
+        add_settings_field('sg_jobs_bexio_token', __('API Token', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_bexio', []);
+            $value = esc_attr($options['token'] ?? '');
+            echo '<input type="password" name="sg_jobs_bexio[token]" value="' . $value . '" class="regular-text" required autocomplete="off" />';
+        }, 'sg-jobs', 'sg_jobs_bexio_section');
+
+        add_settings_section('sg_jobs_caldav_section', __('CalDAV', 'sg-jobs'), function (): void {
+            echo '<p>' . esc_html__('Provide the Nextcloud/SabreDAV credentials used for event creation.', 'sg-jobs') . '</p>';
+        }, 'sg-jobs');
+
+        add_settings_field('sg_jobs_caldav_base', __('Base URL', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_caldav', []);
+            $value = esc_attr($options['base_url'] ?? '');
+            echo '<input type="url" name="sg_jobs_caldav[base_url]" value="' . $value . '" class="regular-text" required />';
+        }, 'sg-jobs', 'sg_jobs_caldav_section');
+
+        add_settings_field('sg_jobs_caldav_user', __('Username', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_caldav', []);
+            $value = esc_attr($options['username'] ?? '');
+            echo '<input type="text" name="sg_jobs_caldav[username]" value="' . $value . '" class="regular-text" required />';
+        }, 'sg-jobs', 'sg_jobs_caldav_section');
+
+        add_settings_field('sg_jobs_caldav_pass', __('Password', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_caldav', []);
+            $value = esc_attr($options['password'] ?? '');
+            echo '<input type="password" name="sg_jobs_caldav[password]" value="' . $value . '" class="regular-text" required autocomplete="off" />';
+        }, 'sg-jobs', 'sg_jobs_caldav_section');
+
+        add_settings_section('sg_jobs_jwt_section', __('Magic links', 'sg-jobs'), function (): void {
+            echo '<p>' . esc_html__('Magic link JWTs authenticate installers without WordPress accounts.', 'sg-jobs') . '</p>';
+        }, 'sg-jobs');
+
+        add_settings_field('sg_jobs_jwt_secret', __('JWT secret', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_jwt', []);
+            $value = esc_attr($options['secret'] ?? '');
+            echo '<input type="password" name="sg_jobs_jwt[secret]" value="' . $value . '" class="regular-text" required autocomplete="off" />';
+        }, 'sg-jobs', 'sg_jobs_jwt_section');
+
+        add_settings_field('sg_jobs_jwt_expire', __('Expiry days', 'sg-jobs'), function (): void {
+            $options = get_option('sg_jobs_jwt', []);
+            $value = esc_attr($options['expiry_days'] ?? '14');
+            echo '<input type="number" min="1" max="60" name="sg_jobs_jwt[expiry_days]" value="' . $value . '" />';
+        }, 'sg-jobs', 'sg_jobs_jwt_section');
+
+        add_settings_section('sg_jobs_teams_section', __('Teams', 'sg-jobs'), function (): void {
+            echo '<p>' . esc_html__('Define execution and blocker calendars for each team.', 'sg-jobs') . '</p>';
+        }, 'sg-jobs');
+
+        add_settings_field('sg_jobs_teams_table', __('Teams configuration', 'sg-jobs'), [$this, 'renderTeamsTable'], 'sg-jobs', 'sg_jobs_teams_section');
+    }
+
+    public function renderPage(): void
+    {
+        echo '<div class="wrap"><h1>' . esc_html__('SG Jobs', 'sg-jobs') . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields('sg_jobs');
+        do_settings_sections('sg-jobs');
+        submit_button();
+        echo '</form></div>';
+    }
+
+    public function renderTeamsTable(): void
+    {
+        $teams = get_option('sg_jobs_teams', []);
+        echo '<table class="widefat">';
+        echo '<thead><tr><th>' . esc_html__('Team name', 'sg-jobs') . '</th><th>' . esc_html__('CalDAV principal', 'sg-jobs') . '</th><th>' . esc_html__('Execution calendar path', 'sg-jobs') . '</th><th>' . esc_html__('Blocker calendar path', 'sg-jobs') . '</th></tr></thead>';
+        echo '<tbody>';
+        for ($i = 0; $i < max(1, count($teams)); $i++) {
+            $team = $teams[$i] ?? [];
+            printf(
+                '<tr><td><input type="text" name="sg_jobs_teams[%1$d][name]" value="%2$s" /></td><td><input type="text" name="sg_jobs_teams[%1$d][principal]" value="%3$s" /></td><td><input type="text" name="sg_jobs_teams[%1$d][calendar]" value="%4$s" /></td><td><input type="text" name="sg_jobs_teams[%1$d][blocker]" value="%5$s" /></td></tr>',
+                $i,
+                esc_attr($team['name'] ?? ''),
+                esc_attr($team['principal'] ?? ''),
+                esc_attr($team['calendar'] ?? ''),
+                esc_attr($team['blocker'] ?? '')
+            );
+        }
+        echo '</tbody></table>';
+        echo '<p class="description">' . esc_html__('Leave blank rows empty to remove teams. CalDAV paths must be full collection URLs.', 'sg-jobs') . '</p>';
+    }
+
+    public function sanitizeArray(array $input): array
+    {
+        foreach ($input as $key => $value) {
+            $input[$key] = is_string($value) ? sanitize_text_field($value) : $value;
+        }
+
+        return $input;
+    }
+
+    public function sanitizeTeams(array $input): array
+    {
+        $teams = [];
+        foreach ($input as $team) {
+            if (empty($team['name']) || empty($team['principal']) || empty($team['calendar'])) {
+                continue;
+            }
+            $teams[] = [
+                'name' => sanitize_text_field($team['name']),
+                'principal' => sanitize_text_field($team['principal']),
+                'calendar' => esc_url_raw($team['calendar']),
+                'blocker' => esc_url_raw($team['blocker'] ?? ''),
+            ];
+        }
+
+        return $teams;
+    }
+}

--- a/src/App/JobsService.php
+++ b/src/App/JobsService.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\App;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use SGJobs\Infra\Bexio\BexioClient;
+use SGJobs\Infra\Bexio\BexioService;
+use SGJobs\Infra\CalDAV\CalDAVClient;
+use SGJobs\Infra\CalDAV\CalendarService;
+use SGJobs\Infra\Security\JwtService;
+use SGJobs\Util\Formatting;
+use WP_Error;
+
+class JobsService
+{
+    private BexioService $bexio;
+
+    private CalendarService $calendar;
+
+    private JwtService $jwt;
+
+    public function __construct()
+    {
+        $this->bexio = new BexioService(new BexioClient());
+        $this->calendar = new CalendarService(new CalDAVClient());
+        $this->jwt = new JwtService();
+    }
+
+    public function createJob(array $payload, int $authorId): array|WP_Error
+    {
+        global $wpdb;
+        $deliveryNote = $this->bexio->getDeliveryNoteByNumber($payload['delivery_note_nr']);
+        if ($deliveryNote instanceof WP_Error) {
+            return $deliveryNote;
+        }
+        $positions = $this->bexio->getDeliveryNotePositions($deliveryNote['id']);
+        if ($positions instanceof WP_Error) {
+            return $positions;
+        }
+
+        $phones = $deliveryNote['phones'];
+        if (empty($phones)) {
+            $phones = $payload['phones'] ?? [];
+            if (empty($phones)) {
+                return new WP_Error('sg_jobs_missing_phone', __('Phone number required when delivery note has none.', 'sg-jobs'));
+            }
+        }
+
+        $tz = new DateTimeZone($payload['timezone'] ?? 'Europe/Zurich');
+        $start = new DateTimeImmutable($payload['starts_at'], $tz);
+        $end = new DateTimeImmutable($payload['ends_at'], $tz);
+        $jobData = [
+            'delivery_note_id' => $deliveryNote['id'],
+            'delivery_note_nr' => $deliveryNote['document_nr'],
+            'sales_order_nr' => $deliveryNote['sales_order_nr'],
+            'team_id' => $payload['team_id'],
+            'starts_at' => $start->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            'ends_at' => $end->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            'tz' => $tz->getName(),
+            'location_city' => sanitize_text_field($payload['location_city']),
+            'address_line' => sanitize_text_field(sprintf('%s, %s %s', $deliveryNote['delivery_address']['address_line1'] ?? '', $deliveryNote['delivery_address']['zip'] ?? '', $deliveryNote['delivery_address']['city'] ?? '')),
+            'phones_json' => wp_json_encode(array_values($phones)),
+            'status' => 'open',
+            'customer_name' => sanitize_text_field($deliveryNote['customer_name']),
+            'notes' => sanitize_textarea_field($payload['notes'] ?? ''),
+            'created_by' => $authorId,
+        ];
+
+        $wpdb->insert($wpdb->prefix . 'sg_jobs', $jobData);
+        $jobId = (int) $wpdb->insert_id;
+
+        foreach ($positions as $index => $position) {
+            $wpdb->insert($wpdb->prefix . 'sg_job_positions', [
+                'job_id' => $jobId,
+                'bexio_position_id' => $position['bexio_position_id'],
+                'article_no' => $position['article_no'],
+                'title' => $position['title'],
+                'description' => $position['description'],
+                'qty' => $position['qty'],
+                'unit' => $position['unit'],
+                'work_type' => 'unknown',
+                'sort' => $index,
+            ]);
+        }
+
+        $token = $this->jwt->createToken(['job_id' => $jobId, 'sub' => 'job:' . $jobId]);
+        $publicUrl = home_url('/jobs/' . rawurlencode($token));
+
+        $jobRow = $this->getJobById($jobId);
+        if ($jobRow instanceof WP_Error) {
+            return $jobRow;
+        }
+        $jobRow['public_url'] = $publicUrl;
+        $jobRow['public_job_url'] = $publicUrl;
+        $uid = $this->calendar->createOrUpdateEvent(Formatting::jobFromRow($jobRow));
+        if ($uid instanceof WP_Error) {
+            return $uid;
+        }
+
+        $wpdb->update($wpdb->prefix . 'sg_jobs', [
+            'caldav_event_uid' => $uid,
+            'job_token_hash' => hash('sha256', $token),
+            'public_job_url' => $publicUrl,
+        ], ['id' => $jobId]);
+
+        return [
+            'job_id' => $jobId,
+            'public_job_url' => $publicUrl,
+            'caldav_event_uid' => $uid,
+        ];
+    }
+
+    public function markStatus(int $jobId, string $status, array $meta = []): bool|WP_Error
+    {
+        global $wpdb;
+        $jobRow = $this->getJobById($jobId);
+        if ($jobRow instanceof WP_Error) {
+            return $jobRow;
+        }
+        $wpdb->update($wpdb->prefix . 'sg_jobs', [
+            'status' => $status,
+            'updated_by' => $meta['actor'] ?? null,
+        ], ['id' => $jobId]);
+        $jobRow['status'] = $status;
+        $jobRow['public_url'] = $jobRow['public_job_url'] ?? '';
+        $job = Formatting::jobFromRow($jobRow);
+        $this->calendar->createOrUpdateEvent($job);
+
+        $this->logAudit($jobId, $status, $meta);
+        return true;
+    }
+
+    public function markBillable(int $jobId, int $actorId): bool|WP_Error
+    {
+        return $this->markStatus($jobId, 'billable', ['actor' => (string) $actorId]);
+    }
+
+    public function markDone(int $jobId, string $comment, string $actor): bool|WP_Error
+    {
+        global $wpdb;
+        $wpdb->update($wpdb->prefix . 'sg_jobs', ['notes' => $comment], ['id' => $jobId]);
+        return $this->markStatus($jobId, 'done', ['actor' => $actor, 'comment' => $comment]);
+    }
+
+    public function markPaid(int $jobId): bool|WP_Error
+    {
+        return $this->markStatus($jobId, 'paid', ['actor' => 'system']);
+    }
+
+    public function getJobById(int $jobId): array|WP_Error
+    {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . $wpdb->prefix . 'sg_jobs WHERE id = %d', $jobId), ARRAY_A);
+        if (! $row) {
+            return new WP_Error('sg_jobs_not_found', __('Job not found.', 'sg-jobs'));
+        }
+        $row['positions'] = $wpdb->get_results($wpdb->prepare('SELECT * FROM ' . $wpdb->prefix . 'sg_job_positions WHERE job_id = %d ORDER BY sort ASC', $jobId), ARRAY_A);
+        $phones = json_decode($row['phones_json'] ?? '[]', true);
+        $row['phones'] = is_array($phones) ? $phones : [];
+        $row['public_url'] = $row['public_job_url'] ?? '';
+        unset($row['phones_json'], $row['job_token_hash']);
+        return $row;
+    }
+
+    private function logAudit(int $jobId, string $action, array $meta): void
+    {
+        global $wpdb;
+        $wpdb->insert($wpdb->prefix . 'sg_job_audit', [
+            'job_id' => $jobId,
+            'actor' => $meta['actor'] ?? 'unknown',
+            'action' => $action,
+            'payload_json' => wp_json_encode($meta),
+        ]);
+    }
+}

--- a/src/App/Sync/BexioPaymentSync.php
+++ b/src/App/Sync/BexioPaymentSync.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\App\Sync;
+
+use SGJobs\App\JobsService;
+use SGJobs\Infra\Bexio\BexioClient;
+use SGJobs\Infra\Bexio\BexioService;
+use SGJobs\Infra\Logging\Logger;
+use WP_Error;
+
+class BexioPaymentSync
+{
+    private BexioService $bexio;
+
+    public function __construct(private JobsService $jobs)
+    {
+        $this->bexio = new BexioService(new BexioClient());
+    }
+
+    public function syncPaidInvoices(): bool|WP_Error
+    {
+        global $wpdb;
+        $jobs = $wpdb->get_results("SELECT id FROM {$wpdb->prefix}sg_jobs WHERE status IN ('billable','done')", ARRAY_A);
+        foreach ($jobs as $jobRow) {
+            $jobId = (int) $jobRow['id'];
+            $job = $this->jobs->getJobById($jobId);
+            if ($job instanceof WP_Error) {
+                continue;
+            }
+            $jobObject = \SGJobs\Util\Formatting::jobFromRow($job);
+            $status = $this->bexio->getInvoicePaymentStatusForJob($jobObject);
+            if ($status instanceof WP_Error) {
+                Logger::instance()->warning('Payment sync failed', ['job_id' => $jobId, 'error' => $status->get_error_message()]);
+                continue;
+            }
+            if ($status) {
+                $this->jobs->markPaid($jobId);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/App/Sync/CalDavWatcher.php
+++ b/src/App/Sync/CalDavWatcher.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\App\Sync;
+
+use SGJobs\Infra\CalDAV\CalDAVClient;
+use SGJobs\Infra\Logging\Logger;
+
+class CalDavWatcher
+{
+    public function __construct(private CalDAVClient $client)
+    {
+    }
+
+    public function pollForChanges(): void
+    {
+        Logger::instance()->info('CalDAV watcher executed', []);
+    }
+}

--- a/src/App/TeamsService.php
+++ b/src/App/TeamsService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\App;
+
+use WP_Error;
+
+class TeamsService
+{
+    public function listTeams(): array
+    {
+        global $wpdb;
+        return $wpdb->get_results('SELECT * FROM ' . $wpdb->prefix . 'sg_teams ORDER BY name ASC', ARRAY_A);
+    }
+
+    public function getTeam(int $teamId): array|WP_Error
+    {
+        global $wpdb;
+        $team = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . $wpdb->prefix . 'sg_teams WHERE id = %d', $teamId), ARRAY_A);
+        if (! $team) {
+            return new WP_Error('sg_jobs_team_missing', __('Team not found.', 'sg-jobs'));
+        }
+
+        return $team;
+    }
+}

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs;
+
+use SGJobs\Admin\SettingsPage;
+use SGJobs\App\JobsService;
+use SGJobs\App\Sync\BexioPaymentSync;
+use SGJobs\Http\Api\JobsController;
+use SGJobs\Http\Api\MagicLinkController;
+use SGJobs\Ui\Board\BoardController;
+use SGJobs\Ui\JobSheet\JobSheetController;
+use WP_Error;
+
+class Bootstrap
+{
+    private static ?self $instance = null;
+
+    private SettingsPage $settingsPage;
+
+    private function __construct()
+    {
+        $this->settingsPage = new SettingsPage();
+    }
+
+    public static function instance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function init(): void
+    {
+        add_action('plugins_loaded', [$this, 'onPluginsLoaded']);
+        if (! defined('SGJOBS_PLUGIN_FILE')) {
+            define('SGJOBS_PLUGIN_FILE', __FILE__);
+        }
+        register_activation_hook(SGJOBS_PLUGIN_FILE, [$this, 'onActivate']);
+        register_deactivation_hook(SGJOBS_PLUGIN_FILE, [$this, 'onDeactivate']);
+    }
+
+    public function onPluginsLoaded(): void
+    {
+        $this->settingsPage->register();
+        (new JobsController())->registerRoutes();
+        (new MagicLinkController())->registerRoutes();
+        (new BoardController())->register();
+        (new JobSheetController())->register();
+
+        add_action('sg_jobs_bexio_payment_sync', [$this, 'handlePaymentSync']);
+        if (! wp_next_scheduled('sg_jobs_bexio_payment_sync')) {
+            wp_schedule_event(time() + 60, 'fifteen_minutes', 'sg_jobs_bexio_payment_sync');
+        }
+
+        add_filter('cron_schedules', static function (array $schedules): array {
+            $schedules['fifteen_minutes'] = [
+                'interval' => 15 * 60,
+                'display' => __('Every 15 Minutes', 'sg-jobs'),
+            ];
+
+            return $schedules;
+        });
+    }
+
+    public function onActivate(): void
+    {
+        $migrations = glob(__DIR__ . '/Infra/DB/Migrations/*.php') ?: [];
+        sort($migrations);
+        global $wpdb;
+        foreach ($migrations as $migration) {
+            require_once $migration;
+            $className = $this->resolveMigrationClass($migration);
+            if ($className && class_exists($className)) {
+                $migrationInstance = new $className($wpdb);
+                $migrationInstance->up();
+            }
+        }
+
+        $role = get_role('administrator');
+        if ($role && ! $role->has_cap('sgjobs_manage')) {
+            $role->add_cap('sgjobs_manage');
+        }
+    }
+
+    public function onDeactivate(): void
+    {
+        wp_clear_scheduled_hook('sg_jobs_bexio_payment_sync');
+    }
+
+    public function handlePaymentSync(): void
+    {
+        $service = new JobsService();
+        $sync = new BexioPaymentSync($service);
+        $result = $sync->syncPaidInvoices();
+        if ($result instanceof WP_Error) {
+            error_log('[SG Jobs] Payment sync failed: ' . $result->get_error_message());
+        }
+    }
+
+    private function resolveMigrationClass(string $path): ?string
+    {
+        $file = pathinfo($path, PATHINFO_FILENAME);
+        $normalized = str_replace(['_', '-'], ' ', $file);
+        $class = 'SGJobs\\Infra\\DB\\Migrations\\Migration' . str_replace(' ', '', ucwords($normalized));
+
+        return $class;
+    }
+}

--- a/src/Domain/EmojiStatus.php
+++ b/src/Domain/EmojiStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain;
+
+class EmojiStatus
+{
+    private const MAP = [
+        'open' => '\u{1F534}',
+        'done' => '\u{2705}',
+        'billable' => '\u{1F9FE}',
+        'paid' => '\u{1F4B0}',
+    ];
+
+    public static function fromStatus(string $status): string
+    {
+        return self::MAP[$status] ?? self::MAP['open'];
+    }
+}

--- a/src/Domain/Entity/Job.php
+++ b/src/Domain/Entity/Job.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\Entity;
+
+use SGJobs\Domain\Entity\JobPosition;
+use SGJobs\Domain\Entity\Team;
+use SGJobs\Domain\EmojiStatus;
+use SGJobs\Domain\ValueObjects\Address;
+use SGJobs\Domain\ValueObjects\PhoneList;
+use SGJobs\Domain\ValueObjects\TimeRange;
+
+class Job
+{
+    public function __construct(
+        private int $id,
+        private int $deliveryNoteId,
+        private string $deliveryNoteNumber,
+        private ?string $salesOrderNumber,
+        private Team $team,
+        private TimeRange $timeRange,
+        private Address $address,
+        private PhoneList $phones,
+        private string $customerName,
+        private string $status,
+        private string $timezone,
+        private ?string $caldavEventUid,
+        private string $publicUrl,
+        private array $positions,
+        private ?string $notes
+    ) {
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function deliveryNoteNumber(): string
+    {
+        return $this->deliveryNoteNumber;
+    }
+
+    public function customerName(): string
+    {
+        return $this->customerName;
+    }
+
+    public function phones(): PhoneList
+    {
+        return $this->phones;
+    }
+
+    public function address(): Address
+    {
+        return $this->address;
+    }
+
+    public function timeRange(): TimeRange
+    {
+        return $this->timeRange;
+    }
+
+    public function team(): Team
+    {
+        return $this->team;
+    }
+
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    public function statusEmoji(): string
+    {
+        return EmojiStatus::fromStatus($this->status);
+    }
+
+    public function salesOrderNumber(): ?string
+    {
+        return $this->salesOrderNumber;
+    }
+
+    public function notes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function caldavEventUid(): ?string
+    {
+        return $this->caldavEventUid;
+    }
+
+    public function publicUrl(): string
+    {
+        return $this->publicUrl;
+    }
+
+    /** @return JobPosition[] */
+    public function positions(): array
+    {
+        return $this->positions;
+    }
+
+    public function withStatus(string $status): self
+    {
+        return new self(
+            $this->id,
+            $this->deliveryNoteId,
+            $this->deliveryNoteNumber,
+            $this->salesOrderNumber,
+            $this->team,
+            $this->timeRange,
+            $this->address,
+            $this->phones,
+            $this->customerName,
+            $status,
+            $this->timezone,
+            $this->caldavEventUid,
+            $this->publicUrl,
+            $this->positions,
+            $this->notes
+        );
+    }
+
+    public function timezone(): string
+    {
+        return $this->timezone;
+    }
+
+    public function deliveryNoteId(): int
+    {
+        return $this->deliveryNoteId;
+    }
+
+    public function timeRangeUtc(): TimeRange
+    {
+        return $this->timeRange->toUtc($this->timezone);
+    }
+}

--- a/src/Domain/Entity/JobPosition.php
+++ b/src/Domain/Entity/JobPosition.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\Entity;
+
+class JobPosition
+{
+    public function __construct(
+        private int $bexioPositionId,
+        private string $articleNumber,
+        private string $title,
+        private string $description,
+        private float $quantity,
+        private string $unit,
+        private string $workType,
+        private int $sort
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'bexio_position_id' => $this->bexioPositionId,
+            'article_no' => $this->articleNumber,
+            'title' => $this->title,
+            'description' => $this->description,
+            'qty' => $this->quantity,
+            'unit' => $this->unit,
+            'work_type' => $this->workType,
+            'sort' => $this->sort,
+        ];
+    }
+}

--- a/src/Domain/Entity/Team.php
+++ b/src/Domain/Entity/Team.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\Entity;
+
+class Team
+{
+    public function __construct(
+        private int $id,
+        private string $name,
+        private string $principal,
+        private string $calendarPath,
+        private string $blockerPath
+    ) {
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function principal(): string
+    {
+        return $this->principal;
+    }
+
+    public function calendarPath(): string
+    {
+        return $this->calendarPath;
+    }
+
+    public function blockerPath(): string
+    {
+        return $this->blockerPath;
+    }
+}

--- a/src/Domain/ValueObjects.php
+++ b/src/Domain/ValueObjects.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain;
+
+// Kept for backwards compatibility - new classes in ValueObjects namespace.

--- a/src/Domain/ValueObjects/Address.php
+++ b/src/Domain/ValueObjects/Address.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\ValueObjects;
+
+class Address
+{
+    public function __construct(
+        private string $street,
+        private string $zip,
+        private string $city,
+        private string $country
+    ) {
+    }
+
+    public function city(): string
+    {
+        return $this->city;
+    }
+
+    public function formatted(): string
+    {
+        return sprintf('%s, %s %s, %s', $this->street, $this->zip, $this->city, $this->country);
+    }
+}

--- a/src/Domain/ValueObjects/PhoneList.php
+++ b/src/Domain/ValueObjects/PhoneList.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\ValueObjects;
+
+class PhoneList
+{
+    /** @var string[] */
+    private array $phones;
+
+    /**
+     * @param string[] $phones
+     */
+    public function __construct(array $phones)
+    {
+        $this->phones = array_values(array_filter(array_map([$this, 'normalise'], $phones)));
+    }
+
+    public function toArray(): array
+    {
+        return $this->phones;
+    }
+
+    private function normalise(string $phone): string
+    {
+        $clean = preg_replace('/[^0-9+]/', '', $phone) ?? '';
+        if ($clean === '' || $clean[0] !== '+') {
+            $clean = '+' . ltrim($clean, '+');
+        }
+
+        return $clean;
+    }
+
+    public function __toString(): string
+    {
+        return implode('; ', $this->phones);
+    }
+}

--- a/src/Domain/ValueObjects/TimeRange.php
+++ b/src/Domain/ValueObjects/TimeRange.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Domain\ValueObjects;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+class TimeRange
+{
+    public function __construct(private DateTimeImmutable $start, private DateTimeImmutable $end)
+    {
+    }
+
+    public function start(): DateTimeImmutable
+    {
+        return $this->start;
+    }
+
+    public function end(): DateTimeImmutable
+    {
+        return $this->end;
+    }
+
+    public function toUtc(string $timezone): self
+    {
+        $tz = new DateTimeZone($timezone);
+        return new self(
+            $this->start->setTimezone($tz)->setTimezone(new DateTimeZone('UTC')),
+            $this->end->setTimezone($tz)->setTimezone(new DateTimeZone('UTC'))
+        );
+    }
+}

--- a/src/Http/Api/JobsController.php
+++ b/src/Http/Api/JobsController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Http\Api;
+
+use SGJobs\App\JobsService;
+use SGJobs\Http\Middleware\Auth;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class JobsController
+{
+    private JobsService $jobs;
+
+    private Auth $auth;
+
+    public function __construct()
+    {
+        $this->jobs = new JobsService();
+        $this->auth = new Auth();
+    }
+
+    public function registerRoutes(): void
+    {
+        add_action('rest_api_init', function (): void {
+            register_rest_route('sgjobs/v1', '/jobs', [
+                'methods' => WP_REST_Server::READABLE,
+                'permission_callback' => [$this->auth, 'allowInstallerOrDispo'],
+                'callback' => [$this, 'listJobs'],
+            ]);
+
+            register_rest_route('sgjobs/v1', '/jobs', [
+                'methods' => WP_REST_Server::CREATABLE,
+                'permission_callback' => [$this->auth, 'requireDispo'],
+                'callback' => [$this, 'createJob'],
+            ]);
+
+            register_rest_route('sgjobs/v1', '/jobs/(?P<id>\\d+)', [
+                'methods' => WP_REST_Server::READABLE,
+                'permission_callback' => [$this->auth, 'allowInstallerOrDispo'],
+                'callback' => [$this, 'getJob'],
+            ]);
+
+            register_rest_route('sgjobs/v1', '/jobs/(?P<id>\\d+)/done', [
+                'methods' => WP_REST_Server::CREATABLE,
+                'permission_callback' => [$this->auth, 'requireInstaller'],
+                'callback' => [$this, 'markDone'],
+            ]);
+
+            register_rest_route('sgjobs/v1', '/jobs/(?P<id>\\d+)/billable', [
+                'methods' => WP_REST_Server::CREATABLE,
+                'permission_callback' => [$this->auth, 'requireDispo'],
+                'callback' => [$this, 'markBillable'],
+            ]);
+        });
+    }
+
+    public function listJobs(\WP_REST_Request $request)
+    {
+        // Placeholder board data until board service is implemented
+        return [
+            'jobs' => [],
+            'blockers' => []
+        ];
+    }
+
+    public function createJob(WP_REST_Request $request)
+    {
+        $payload = $request->get_json_params();
+        $result = $this->jobs->createJob($payload, get_current_user_id());
+        if ($result instanceof \WP_Error) {
+            return $this->auth->toRestError($result);
+        }
+
+        return $result;
+    }
+
+    public function getJob(WP_REST_Request $request)
+    {
+        $jobId = (int) $request['id'];
+        $result = $this->jobs->getJobById($jobId);
+        if ($result instanceof \WP_Error) {
+            return $this->auth->toRestError($result);
+        }
+
+        return $result;
+    }
+
+    public function markDone(WP_REST_Request $request)
+    {
+        $jobId = (int) $request['id'];
+        $comment = $request->get_json_params()['comment'] ?? '';
+        $tokenClaims = $this->auth->currentInstallerClaims();
+        $result = $this->jobs->markDone($jobId, $comment, $tokenClaims['sub'] ?? 'installer');
+        if ($result instanceof \WP_Error) {
+            return $this->auth->toRestError($result);
+        }
+
+        return ['status' => 'done'];
+    }
+
+    public function markBillable(WP_REST_Request $request)
+    {
+        $jobId = (int) $request['id'];
+        $result = $this->jobs->markBillable($jobId, get_current_user_id());
+        if ($result instanceof \WP_Error) {
+            return $this->auth->toRestError($result);
+        }
+
+        return ['status' => 'billable'];
+    }
+}

--- a/src/Http/Api/MagicLinkController.php
+++ b/src/Http/Api/MagicLinkController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Http\Api;
+
+use SGJobs\App\JobsService;
+use SGJobs\Http\Middleware\Auth;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class MagicLinkController
+{
+    private JobsService $jobs;
+
+    private Auth $auth;
+
+    public function __construct()
+    {
+        $this->jobs = new JobsService();
+        $this->auth = new Auth();
+    }
+
+    public function registerRoutes(): void
+    {
+        add_action('rest_api_init', function (): void {
+            register_rest_route('sgjobs/v1', '/my-jobs', [
+                'methods' => WP_REST_Server::READABLE,
+                'permission_callback' => [$this->auth, 'requireInstaller'],
+                'callback' => [$this, 'listJobs'],
+            ]);
+
+            register_rest_route('sgjobs/v1', '/jobs/by-token/(?P<token>[^/]+)', [
+                'methods' => WP_REST_Server::READABLE,
+                'permission_callback' => '__return_true',
+                'callback' => [$this, 'jobByToken'],
+            ]);
+        });
+    }
+
+    public function listJobs(WP_REST_Request $request)
+    {
+        // Simplified response placeholder
+        return [
+            'jobs' => [],
+        ];
+    }
+
+    public function jobByToken(WP_REST_Request $request)
+    {
+        $token = $request['token'];
+        $claims = $this->auth->validateInstallerToken($token);
+        if ($claims instanceof \WP_Error) {
+            return $this->auth->toRestError($claims);
+        }
+        $jobId = (int) ($claims['job_id'] ?? 0);
+        if (! $jobId) {
+            return $this->auth->toRestError(new \WP_Error('sg_jobs_invalid_token', __('Token enthält keine Job-ID.', 'sg-jobs')));
+        }
+        $job = $this->jobs->getJobById($jobId);
+        if ($job instanceof \WP_Error) {
+            return $this->auth->toRestError($job);
+        }
+        return $job;
+    }
+}

--- a/src/Http/Middleware/Auth.php
+++ b/src/Http/Middleware/Auth.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Http\Middleware;
+
+use SGJobs\Infra\Security\JwtService;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class Auth
+{
+    private ?array $installerClaims = null;
+
+    private JwtService $jwt;
+
+    public function __construct()
+    {
+        $this->jwt = new JwtService();
+    }
+
+    public function requireDispo(): bool
+    {
+        return current_user_can('sgjobs_manage');
+    }
+
+    public function allowInstallerOrDispo(): bool
+    {
+        return $this->requireDispo() || $this->requireInstaller();
+    }
+
+    public function requireInstaller(): bool
+    {
+        $header = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        if (! str_starts_with($header, 'Bearer ')) {
+            return false;
+        }
+        $token = substr($header, 7);
+        $claims = $this->jwt->validateToken($token);
+        if ($claims instanceof WP_Error) {
+            return false;
+        }
+        $this->installerClaims = $claims;
+        return true;
+    }
+
+    public function currentInstallerClaims(): array
+    {
+        return $this->installerClaims ?? [];
+    }
+
+    public function validateInstallerToken(string $token): array|WP_Error
+    {
+        return $this->jwt->validateToken($token);
+    }
+
+    public function toRestError(WP_Error $error)
+    {
+        return new WP_REST_Response([
+            'error' => [
+                'code' => $error->get_error_code(),
+                'message' => $error->get_error_message(),
+            ],
+        ], (int) ($error->get_error_data() ?: 400));
+    }
+}

--- a/src/Infra/Bexio/BexioClient.php
+++ b/src/Infra/Bexio/BexioClient.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\Bexio;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+use SGJobs\Infra\Logging\Logger;
+use Throwable;
+
+class BexioClient
+{
+    private Client $client;
+
+    private LoggerInterface $logger;
+
+    public function __construct(?Client $client = null, ?LoggerInterface $logger = null)
+    {
+        $options = get_option('sg_jobs_bexio', []);
+        $baseUrl = $options['base_url'] ?? getenv('BEXIO_BASE_URL') ?: '';
+        $token = $options['token'] ?? getenv('BEXIO_API_TOKEN') ?: '';
+        $this->client = $client ?: new Client([
+            'base_uri' => $baseUrl,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Accept' => 'application/json',
+            ],
+            'timeout' => 10,
+        ]);
+        $this->logger = $logger ?: Logger::instance();
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    public function get(string $path, array $query = []): array
+    {
+        $attempts = 0;
+        $maxAttempts = 5;
+        $delay = 0.2;
+        while (true) {
+            try {
+                $response = $this->client->get($path, ['query' => $query]);
+                return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            } catch (GuzzleException $exception) {
+                $attempts++;
+                if ($attempts >= $maxAttempts) {
+                    throw $exception;
+                }
+                $this->logger->warning('Retrying bexio request', ['path' => $path, 'error' => $exception->getMessage(), 'attempt' => $attempts]);
+                usleep((int) ($delay * 1e6));
+                $delay = min($delay * 2, 3.0);
+            } catch (Throwable $error) {
+                $this->logger->error('Unexpected bexio error', ['path' => $path, 'error' => $error->getMessage()]);
+                throw $error;
+            }
+        }
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    public function post(string $path, array $payload): array
+    {
+        $response = $this->client->post($path, ['json' => $payload]);
+        return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Infra/Bexio/BexioService.php
+++ b/src/Infra/Bexio/BexioService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\Bexio;
+
+use GuzzleHttp\Exception\GuzzleException;
+use SGJobs\Domain\Entity\Job;
+use WP_Error;
+
+class BexioService
+{
+    public function __construct(private BexioClient $client)
+    {
+    }
+
+    public function getDeliveryNoteByNumber(string $number): array|WP_Error
+    {
+        try {
+            $notes = $this->client->get('/kb_delivery_notes', ['document_nr' => $number]);
+            if (! $notes) {
+                return new WP_Error('sg_jobs_delivery_note_missing', __('Delivery note not found in bexio.', 'sg-jobs'));
+            }
+            $note = $notes[0];
+            return [
+                'id' => (int) $note['id'],
+                'document_nr' => $note['document_nr'],
+                'customer_name' => $note['contact_name'] ?? '',
+                'delivery_address' => $note['delivery_address'],
+                'phones' => $this->extractPhones($note),
+                'sales_order_nr' => $note['reference'] ?? null,
+            ];
+        } catch (GuzzleException $exception) {
+            return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
+        }
+    }
+
+    public function getDeliveryNotePositions(int $deliveryNoteId): array|WP_Error
+    {
+        try {
+            $positions = $this->client->get(sprintf('/kb_delivery_notes/%d/positions', $deliveryNoteId));
+            return array_map(static function (array $position): array {
+                return [
+                    'bexio_position_id' => (int) $position['id'],
+                    'article_no' => (string) ($position['article_nr'] ?? ''),
+                    'title' => (string) $position['text'],
+                    'description' => (string) ($position['description'] ?? ''),
+                    'qty' => (float) $position['amount'],
+                    'unit' => (string) $position['unit_name'],
+                ];
+            }, $positions);
+        } catch (GuzzleException $exception) {
+            return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
+        }
+    }
+
+    public function appendNoteToDeliveryNote(int $deliveryNoteId, string $text): bool|WP_Error
+    {
+        try {
+            $this->client->post(sprintf('/kb_delivery_notes/%d/comments', $deliveryNoteId), ['content' => $text]);
+            return true;
+        } catch (GuzzleException $exception) {
+            return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
+        }
+    }
+
+    public function getInvoicePaymentStatusForJob(Job $job): bool|WP_Error
+    {
+        $salesOrder = $job->salesOrderNumber();
+        if (! $salesOrder) {
+            return false;
+        }
+
+        try {
+            $invoices = $this->client->get('/kb_invoices', ['document_nr' => $salesOrder]);
+            if (! $invoices) {
+                return false;
+            }
+            $invoice = $invoices[0];
+            return isset($invoice['is_paid']) && (bool) $invoice['is_paid'];
+        } catch (GuzzleException $exception) {
+            return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
+        }
+    }
+
+    private function extractPhones(array $note): array
+    {
+        $phones = [];
+        if (! empty($note['delivery_address']['phone'])) {
+            $phones[] = $note['delivery_address']['phone'];
+        }
+        if (! empty($note['delivery_address']['mobile'])) {
+            $phones[] = $note['delivery_address']['mobile'];
+        }
+        return $phones;
+    }
+}

--- a/src/Infra/CalDAV/CalDAVClient.php
+++ b/src/Infra/CalDAV/CalDAVClient.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\CalDAV;
+
+use GuzzleHttp\Client;
+
+class CalDAVClient
+{
+    private Client $client;
+
+    public function __construct(?Client $client = null)
+    {
+        $options = get_option('sg_jobs_caldav', []);
+        $base = $options['base_url'] ?? getenv('CALDAV_BASE_URL') ?: '';
+        $user = $options['username'] ?? getenv('CALDAV_USER') ?: '';
+        $pass = $options['password'] ?? getenv('CALDAV_PASS') ?: '';
+        $this->client = $client ?: new Client([
+            'base_uri' => $base,
+            'auth' => [$user, $pass],
+            'timeout' => 10,
+        ]);
+    }
+
+    public function request(string $method, string $path, array $options = []): string
+    {
+        $response = $this->client->request($method, $path, $options);
+        return (string) $response->getBody();
+    }
+}

--- a/src/Infra/CalDAV/CalendarService.php
+++ b/src/Infra/CalDAV/CalendarService.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\CalDAV;
+
+use DateTimeImmutable;
+use SGJobs\Domain\Entity\Job;
+use SGJobs\Util\Formatting;
+use WP_Error;
+
+class CalendarService
+{
+    public function __construct(private CalDAVClient $client)
+    {
+    }
+
+    public function createOrUpdateEvent(Job $job): string|WP_Error
+    {
+        $uid = $job->caldavEventUid() ?: $this->generateUid($job);
+        $timeRange = $job->timeRangeUtc();
+        $summary = Formatting::formatTitle($job);
+        $description = Formatting::formatDescription($job);
+        $location = Formatting::formatLocation($job);
+        $ics = $this->buildVevent($uid, $timeRange->start(), $timeRange->end(), $summary, $description, $location, $job->publicUrl());
+
+        try {
+            $path = $job->team()->calendarPath() . $uid . '.ics';
+            $this->client->request('PUT', $path, ['body' => $ics, 'headers' => ['Content-Type' => 'text/calendar']]);
+            return $uid;
+        } catch (\Throwable $exception) {
+            return new WP_Error('sg_jobs_caldav', $exception->getMessage());
+        }
+    }
+
+    public function updateTitleEmoji(Job $job, string $status): bool|WP_Error
+    {
+        $summary = Formatting::formatTitle($job->withStatus($status));
+        $body = sprintf("BEGIN:VNOTE\nSUMMARY:%s\nEND:VNOTE", $summary);
+        try {
+            $this->client->request('PUT', $job->team()->calendarPath() . $job->caldavEventUid() . '.summary', ['body' => $body]);
+            return true;
+        } catch (\Throwable $exception) {
+            return new WP_Error('sg_jobs_caldav', $exception->getMessage());
+        }
+    }
+
+    public function updateDescriptionBlock(Job $job): bool|WP_Error
+    {
+        $description = Formatting::formatDescription($job);
+        $body = sprintf("BEGIN:VNOTE\nBODY:%s\nEND:VNOTE", $description);
+        try {
+            $this->client->request('PUT', $job->team()->calendarPath() . $job->caldavEventUid() . '.description', ['body' => $body]);
+            return true;
+        } catch (\Throwable $exception) {
+            return new WP_Error('sg_jobs_caldav', $exception->getMessage());
+        }
+    }
+
+    private function buildVevent(string $uid, DateTimeImmutable $start, DateTimeImmutable $end, string $summary, string $description, string $location, string $url): string
+    {
+        $template = "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//SG Jobs//Plugin//EN\nBEGIN:VEVENT\nUID:%s\nDTSTAMP:%s\nDTSTART:%s\nDTEND:%s\nSUMMARY:%s\nDESCRIPTION:%s\nLOCATION:%s\nURL:%s\nEND:VEVENT\nEND:VCALENDAR";
+        return sprintf(
+            $template,
+            $uid,
+            $start->format('Ymd\THis\Z'),
+            $start->format('Ymd\THis\Z'),
+            $end->format('Ymd\THis\Z'),
+            $this->escape($summary),
+            $this->escape($description),
+            $this->escape($location),
+            $this->escape($url)
+        );
+    }
+
+    private function escape(string $value): string
+    {
+        return str_replace(["\n", ',', ';'], ['\\n', '\\,', '\\;'], $value);
+    }
+
+    private function generateUid(Job $job): string
+    {
+        return sprintf('sgjobs-%d-%s', $job->id(), uniqid('evt', true));
+    }
+}

--- a/src/Infra/DB/Migrations/001_create_jobs_table.php
+++ b/src/Infra/DB/Migrations/001_create_jobs_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\DB\Migrations;
+
+use wpdb;
+
+class Migration001CreateJobsTable
+{
+    public function __construct(private wpdb $wpdb)
+    {
+    }
+
+    public function up(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $this->wpdb->get_charset_collate();
+        $table = $this->wpdb->prefix . 'sg_jobs';
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            delivery_note_id BIGINT UNSIGNED NOT NULL,
+            delivery_note_nr VARCHAR(64) NOT NULL,
+            sales_order_nr VARCHAR(64) NULL,
+            team_id BIGINT UNSIGNED NOT NULL,
+            starts_at DATETIME NOT NULL,
+            ends_at DATETIME NOT NULL,
+            tz VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich',
+            location_city VARCHAR(128) NOT NULL,
+            customer_name VARCHAR(191) NOT NULL,
+            address_line TEXT NOT NULL,
+            phones_json LONGTEXT NOT NULL,
+            status VARCHAR(16) NOT NULL DEFAULT 'open',
+            caldav_event_uid VARCHAR(255) NULL,
+            job_token_hash VARCHAR(64) NULL,
+            public_job_url TEXT NOT NULL,
+            notes TEXT NULL,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY delivery_note_nr (delivery_note_nr),
+            KEY caldav_event_uid (caldav_event_uid)
+        ) {$charset};";
+        dbDelta($sql);
+    }
+}

--- a/src/Infra/DB/Migrations/002_create_job_positions_table.php
+++ b/src/Infra/DB/Migrations/002_create_job_positions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\DB\Migrations;
+
+use wpdb;
+
+class Migration002CreateJobPositionsTable
+{
+    public function __construct(private wpdb $wpdb)
+    {
+    }
+
+    public function up(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $this->wpdb->get_charset_collate();
+        $table = $this->wpdb->prefix . 'sg_job_positions';
+        $jobs = $this->wpdb->prefix . 'sg_jobs';
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            job_id BIGINT UNSIGNED NOT NULL,
+            bexio_position_id BIGINT UNSIGNED NOT NULL,
+            article_no VARCHAR(64) NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            description TEXT NULL,
+            qty DECIMAL(10,2) NOT NULL DEFAULT 0,
+            unit VARCHAR(16) NOT NULL,
+            work_type VARCHAR(16) NOT NULL DEFAULT 'unknown',
+            sort INT NOT NULL DEFAULT 0,
+            PRIMARY KEY (id),
+            KEY job_id (job_id),
+            CONSTRAINT fk_job_positions_job FOREIGN KEY (job_id) REFERENCES {$jobs}(id) ON DELETE CASCADE
+        ) {$charset};";
+        dbDelta($sql);
+    }
+}

--- a/src/Infra/DB/Migrations/003_create_teams_table.php
+++ b/src/Infra/DB/Migrations/003_create_teams_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\DB\Migrations;
+
+use wpdb;
+
+class Migration003CreateTeamsTable
+{
+    public function __construct(private wpdb $wpdb)
+    {
+    }
+
+    public function up(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $this->wpdb->get_charset_collate();
+        $table = $this->wpdb->prefix . 'sg_teams';
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            name VARCHAR(191) NOT NULL,
+            caldav_principal VARCHAR(255) NOT NULL,
+            team_calendar_path TEXT NOT NULL,
+            blocker_calendar_path TEXT NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY name (name)
+        ) {$charset};";
+        dbDelta($sql);
+    }
+}

--- a/src/Infra/DB/Migrations/004_create_users_teams_table.php
+++ b/src/Infra/DB/Migrations/004_create_users_teams_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\DB\Migrations;
+
+use wpdb;
+
+class Migration004CreateUsersTeamsTable
+{
+    public function __construct(private wpdb $wpdb)
+    {
+    }
+
+    public function up(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $this->wpdb->get_charset_collate();
+        $table = $this->wpdb->prefix . 'sg_users_teams';
+        $teams = $this->wpdb->prefix . 'sg_teams';
+        $users = $this->wpdb->users;
+        $sql = "CREATE TABLE {$table} (
+            user_id BIGINT UNSIGNED NOT NULL,
+            team_id BIGINT UNSIGNED NOT NULL,
+            PRIMARY KEY (user_id, team_id),
+            KEY team_id (team_id),
+            CONSTRAINT fk_users_teams_user FOREIGN KEY (user_id) REFERENCES {$users}(ID) ON DELETE CASCADE,
+            CONSTRAINT fk_users_teams_team FOREIGN KEY (team_id) REFERENCES {$teams}(id) ON DELETE CASCADE
+        ) {$charset};";
+        dbDelta($sql);
+    }
+}

--- a/src/Infra/DB/Migrations/005_create_job_audit_table.php
+++ b/src/Infra/DB/Migrations/005_create_job_audit_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\DB\Migrations;
+
+use wpdb;
+
+class Migration005CreateJobAuditTable
+{
+    public function __construct(private wpdb $wpdb)
+    {
+    }
+
+    public function up(): void
+    {
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $this->wpdb->get_charset_collate();
+        $table = $this->wpdb->prefix . 'sg_job_audit';
+        $jobs = $this->wpdb->prefix . 'sg_jobs';
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            job_id BIGINT UNSIGNED NOT NULL,
+            actor VARCHAR(191) NOT NULL,
+            action VARCHAR(64) NOT NULL,
+            payload_json LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY job_id (job_id),
+            CONSTRAINT fk_job_audit_job FOREIGN KEY (job_id) REFERENCES {$jobs}(id) ON DELETE CASCADE
+        ) {$charset};";
+        dbDelta($sql);
+    }
+}

--- a/src/Infra/Logging/Logger.php
+++ b/src/Infra/Logging/Logger.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\Logging;
+
+use Psr\Log\AbstractLogger;
+
+class Logger extends AbstractLogger
+{
+    private static ?self $instance = null;
+
+    public static function instance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $entry = sprintf('[SG Jobs][%s] %s %s', strtoupper((string) $level), $message, wp_json_encode($context));
+        error_log($entry);
+    }
+}

--- a/src/Infra/Queue/QueueService.php
+++ b/src/Infra/Queue/QueueService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\Queue;
+
+class QueueService
+{
+    public function dispatch(string $hook, array $args = [], int $delay = 0): void
+    {
+        if ($delay > 0) {
+            as_schedule_single_action(time() + $delay, $hook, $args, 'sg-jobs');
+        } else {
+            as_enqueue_async_action($hook, $args, 'sg-jobs');
+        }
+    }
+}

--- a/src/Infra/Security/JwtService.php
+++ b/src/Infra/Security/JwtService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\Security;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use WP_Error;
+
+class JwtService
+{
+    private string $secret;
+
+    private int $expiryDays;
+
+    public function __construct()
+    {
+        $options = get_option('sg_jobs_jwt', []);
+        $this->secret = $options['secret'] ?? getenv('JWT_SECRET') ?? '';
+        $this->expiryDays = (int) ($options['expiry_days'] ?? getenv('JWT_EXPIRE_DAYS') ?? 14);
+    }
+
+    public function createToken(array $claims): string
+    {
+        $payload = array_merge($claims, [
+            'iat' => time(),
+            'exp' => time() + ($this->expiryDays * DAY_IN_SECONDS),
+            'nonce' => wp_generate_password(12, false),
+        ]);
+
+        return JWT::encode($payload, $this->secret, 'HS256');
+    }
+
+    public function validateToken(string $token): array|WP_Error
+    {
+        try {
+            return (array) JWT::decode($token, new Key($this->secret, 'HS256'));
+        } catch (\Throwable $exception) {
+            return new WP_Error('sg_jobs_invalid_token', $exception->getMessage());
+        }
+    }
+}

--- a/src/Infra/WebDAV/NextcloudStorage.php
+++ b/src/Infra/WebDAV/NextcloudStorage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Infra\WebDAV;
+
+class NextcloudStorage
+{
+    public function createSignedUploadUrl(string $path, int $expiresIn): string
+    {
+        $base = rtrim(getenv('CALDAV_BASE_URL') ?: '', '/');
+        $token = hash_hmac('sha256', $path . time(), wp_salt('auth'));
+        return sprintf('%s/uploads%s?token=%s&expires=%d', $base, $path, $token, time() + $expiresIn);
+    }
+}

--- a/src/Ui/Admin/SettingsView.php
+++ b/src/Ui/Admin/SettingsView.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Ui\Admin;
+
+class SettingsView
+{
+    public static function renderNotice(string $message, string $type = 'info'): void
+    {
+        printf('<div class="notice notice-%s"><p>%s</p></div>', esc_attr($type), esc_html($message));
+    }
+}

--- a/src/Ui/Board/BoardController.php
+++ b/src/Ui/Board/BoardController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Ui\Board;
+
+class BoardController
+{
+    public function register(): void
+    {
+        add_shortcode('sg_jobs_board', [$this, 'render']);
+    }
+
+    public function render(): string
+    {
+        if (! current_user_can('sgjobs_manage')) {
+            return esc_html__('You do not have permission to view the board.', 'sg-jobs');
+        }
+        wp_enqueue_script('sg-jobs-board', plugins_url('dist/board.js', SGJOBS_PLUGIN_FILE), [], '0.1.0', true);
+        wp_enqueue_style('sg-jobs-board', plugins_url('dist/board.css', SGJOBS_PLUGIN_FILE), [], '0.1.0');
+
+        return '<div id="sg-jobs-board"></div>';
+    }
+}

--- a/src/Ui/Board/assets/board.tsx
+++ b/src/Ui/Board/assets/board.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import FullCalendar from '@fullcalendar/react';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import dayjs from 'dayjs';
+
+type JobEvent = {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+  status: string;
+};
+
+const BoardApp: React.FC = () => {
+  const [events, setEvents] = useState<JobEvent[]>([]);
+
+  useEffect(() => {
+    fetch('/wp-json/sgjobs/v1/jobs?date=' + dayjs().format('YYYY-MM-DD'))
+      .then((res) => res.json())
+      .then((data) => setEvents(data.jobs || []))
+      .catch((err) => console.error('Failed loading jobs', err));
+  }, []);
+
+  return (
+    <div className="sg-jobs-board">
+      <header>
+        <h1>Disposition</h1>
+        <p>Live-Daten aus bexio Delivery Notes inklusive Blocker-Überlagerung.</p>
+      </header>
+      <FullCalendar
+        plugins={[timeGridPlugin, dayGridPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
+        events={events}
+        slotDuration="00:30:00"
+        height="auto"
+      />
+    </div>
+  );
+};
+
+const container = document.getElementById('sg-jobs-board');
+if (container) {
+  createRoot(container).render(<BoardApp />);
+}

--- a/src/Ui/JobSheet/JobSheetController.php
+++ b/src/Ui/JobSheet/JobSheetController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Ui\JobSheet;
+
+class JobSheetController
+{
+    public function register(): void
+    {
+        add_shortcode('sg_jobs_mine', [$this, 'renderList']);
+        add_rewrite_rule('jobs/([^/]+)/?$', 'index.php?sg_jobs_token=$matches[1]', 'top');
+        add_filter('query_vars', function (array $vars): array {
+            $vars[] = 'sg_jobs_token';
+            return $vars;
+        });
+        add_action('template_redirect', [$this, 'renderJob']);
+    }
+
+    public function renderList(): string
+    {
+        wp_enqueue_script('sg-jobs-sheet', plugins_url('dist/jobsheet.js', SGJOBS_PLUGIN_FILE), [], '0.1.0', true);
+        wp_enqueue_style('sg-jobs-sheet', plugins_url('dist/jobsheet.css', SGJOBS_PLUGIN_FILE), [], '0.1.0');
+        return '<div id="sg-jobs-sheet"></div>';
+    }
+
+    public function renderJob(): void
+    {
+        $token = get_query_var('sg_jobs_token');
+        if (! $token) {
+            return;
+        }
+        status_header(200);
+        nocache_headers();
+        readfile(plugin_dir_path(SGJOBS_PLUGIN_FILE) . 'public/jobs/index.php');
+        exit;
+    }
+}

--- a/src/Ui/JobSheet/assets/jobsheet.tsx
+++ b/src/Ui/JobSheet/assets/jobsheet.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+type Job = {
+  id: number;
+  delivery_note_nr: string;
+  customer_name: string;
+  phones: string[];
+  notes: string;
+};
+
+const JobSheet: React.FC = () => {
+  const [job, setJob] = useState<Job | null>(null);
+  const [comment, setComment] = useState('');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    const token = window.location.pathname.split('/').filter(Boolean).pop() || '';
+    fetch(`/wp-json/sgjobs/v1/jobs/by-token/${token}`)
+      .then((res) => res.json())
+      .then((data) => setJob(data));
+  }, []);
+
+  const markDone = () => {
+    if (!job) {
+      return;
+    }
+    const token = window.location.pathname.split('/').filter(Boolean).pop() || '';
+    fetch(`/wp-json/sgjobs/v1/jobs/${job.id}/done`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ comment }),
+    })
+      .then((res) => res.json())
+      .then(() => setStatus('done'));
+  };
+
+  if (!job) {
+    return <p>Lade Jobdaten ...</p>;
+  }
+
+  return (
+    <div className="jobsheet">
+      <h1>✅ Lieferschein {job.delivery_note_nr}</h1>
+      <h2>{job.customer_name}</h2>
+      <div className="phones">
+        {job.phones.map((phone) => (
+          <a key={phone} href={`tel:${phone}`} className="phone-btn">
+            {phone}
+          </a>
+        ))}
+      </div>
+      <textarea value={comment} onChange={(e) => setComment(e.target.value)} placeholder="Kommentar oder Seriennummer" />
+      <button type="button" onClick={markDone} disabled={status === 'done'}>
+        ✅ Auftrag erledigt
+      </button>
+      {status === 'done' && <p className="status">Danke! Status aktualisiert.</p>}
+    </div>
+  );
+};
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/wp-content/plugins/sg-jobs/public/sw.js').catch(console.error);
+}
+
+const container = document.getElementById('sg-jobs-sheet');
+if (container) {
+  createRoot(container).render(<JobSheet />);
+}

--- a/src/Util/Formatting.php
+++ b/src/Util/Formatting.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SGJobs\Util;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use SGJobs\Domain\EmojiStatus;
+use SGJobs\Domain\Entity\Job;
+use SGJobs\Domain\Entity\JobPosition;
+use SGJobs\Domain\Entity\Team;
+use SGJobs\Domain\ValueObjects\Address;
+use SGJobs\Domain\ValueObjects\PhoneList;
+use SGJobs\Domain\ValueObjects\TimeRange;
+
+class Formatting
+{
+    public static function formatTitle(Job $job): string
+    {
+        return sprintf('%s %s | %s | %s', $job->statusEmoji(), $job->address()->city(), $job->deliveryNoteNumber(), $job->customerName());
+    }
+
+    public static function formatLocation(Job $job): string
+    {
+        return $job->address()->city();
+    }
+
+    public static function formatDescription(Job $job): string
+    {
+        $phones = implode('; ', $job->phones()->toArray());
+        $notes = $job->notes() ?: '-';
+        return sprintf(
+            "LieferscheinNr: %s\nAuftragNr: %s\nKunde: %s\nTelefon: %s\nAdresse: %s\nHinweise: %s\nJob-URL: %s\nStatus: %s",
+            $job->deliveryNoteNumber(),
+            $job->salesOrderNumber() ?: '-',
+            $job->customerName(),
+            $phones ?: '-',
+            $job->address()->formatted(),
+            $notes,
+            $job->publicUrl(),
+            $job->status()
+        );
+    }
+
+    public static function jobFromRow(array $row): Job
+    {
+        global $wpdb;
+        $teamRow = $wpdb->get_row($wpdb->prepare('SELECT * FROM ' . $wpdb->prefix . 'sg_teams WHERE id = %d', (int) $row['team_id']), ARRAY_A);
+        $team = new Team((int) $row['team_id'], $teamRow['name'] ?? 'Team', $teamRow['caldav_principal'] ?? '', $teamRow['team_calendar_path'] ?? '', $teamRow['blocker_calendar_path'] ?? '');
+        $start = new DateTimeImmutable($row['starts_at'], new DateTimeZone('UTC'));
+        $end = new DateTimeImmutable($row['ends_at'], new DateTimeZone('UTC'));
+        $phonesArray = json_decode($row['phones_json'] ?? '[]', true);
+        if (!is_array($phonesArray)) {
+            $phonesArray = [];
+        }
+        $phones = new PhoneList($phonesArray);
+        $timeRange = new TimeRange($start, $end);
+        $address = new Address($row['address_line'] ?? '', '', $row['location_city'], 'CH');
+        $positions = array_map(static function (array $pos): JobPosition {
+            return new JobPosition($pos['bexio_position_id'], $pos['article_no'], $pos['title'], $pos['description'], (float) $pos['qty'], $pos['unit'], $pos['work_type'], (int) $pos['sort']);
+        }, $row['positions'] ?? []);
+
+        return new Job(
+            (int) $row['id'],
+            (int) $row['delivery_note_id'],
+            $row['delivery_note_nr'],
+            $row['sales_order_nr'],
+            $team,
+            $timeRange,
+            $address,
+            $phones,
+            $row['customer_name'] ?? '',
+            $row['status'],
+            $row['tz'],
+            $row['caldav_event_uid'] ?? null,
+            $row['public_url'] ?? '',
+            $positions,
+            $row['notes'] ?? null
+        );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "baseUrl": "."
+  },
+  "include": ["src/Ui/**/*.ts", "src/Ui/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: false,
+    rollupOptions: {
+      input: {
+        board: 'src/Ui/Board/assets/board.tsx',
+        jobsheet: 'src/Ui/JobSheet/assets/jobsheet.tsx'
+      },
+      output: {
+        entryFileNames: '[name].js',
+        assetFileNames: '[name].[ext]'
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace the mockup screenshots with vector SVG wireframes to avoid binary assets while keeping the same visual guidance
- update the PWA icon set to simple SVG placeholders and point the manifest to the new files
- adjust documentation links so they reference the new SVG assets instead of PNG files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df043856d88322bc48ef1143e39207