### PR TITLE
Improve static analysis and linting setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,7 +2,8 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: ['./tsconfig.json']
+    project: ['./tsconfig.json', './tsconfig.eslint.json'],
+    tsconfigRootDir: __dirname
   },
   plugins: ['@typescript-eslint', 'react', 'react-hooks'],
   extends: [
@@ -11,6 +12,7 @@ module.exports = {
     'airbnb-typescript'
   ],
   rules: {
-    'react/react-in-jsx-scope': 'off'
+    'react/react-in-jsx-scope': 'off',
+    'no-console': ['error', { allow: ['error', 'warn'] }]
   }
 };

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,14 @@
     "php": "^8.2",
     "guzzlehttp/guzzle": "^7.8",
     "firebase/php-jwt": "^6.10",
-    "johnbillion/extended-cpts": "^5.0"
+    "johnbillion/extended-cpts": "^5.0",
+    "psr/log": "^3.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.11",
     "squizlabs/php_codesniffer": "^3.9",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "php-stubs/wordpress-stubs": "^6.8"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "analyse": "phpstan analyse src",
+    "analyse": "phpstan analyse --memory-limit=1G src",
     "cs": "phpcs --standard=PSR12 src",
     "fix": "phpcbf --standard=PSR12 src"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "823b965e8ef01c4d1ddee7f2100939ab",
+    "content-hash": "d7774a52899586bf7766f51f3cfa3b98",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -928,6 +928,56 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -1135,6 +1185,57 @@
                 }
             ],
             "time": "2025-07-17T20:45:56+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
+            },
+            "time": "2025-07-16T06:41:00+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/interaction": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "@tsconfig/recommended": "^1.0.5"
   },
   "dependencies": {
-  "@fullcalendar/core": "^6.1.15",
-  "@fullcalendar/timegrid": "^6.1.15",
-  "@fullcalendar/interaction": "^6.1.15",
-  "@fullcalendar/react": "^6.1.15",
-  "axios": "^1.6.7",
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
+    "axios": "^1.6.7",
     "dayjs": "^1.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+    paths:
+        - src
+    bootstrapFiles:
+        - vendor/autoload.php
+        - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+        - stubs/wordpress.php

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,20 +1,27 @@
+/* eslint-env serviceworker */
+/* eslint-disable no-restricted-globals */
+
 const VERSION = 'sgjobs-sw-v1';
 const STATIC_CACHE = `${VERSION}-static`;
 const OFFLINE_URLS = [
   '/wp-content/plugins/sg-jobs/dist/jobsheet.js',
-  '/wp-content/plugins/sg-jobs/dist/jobsheet.css'
+  '/wp-content/plugins/sg-jobs/dist/jobsheet.css',
 ];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(STATIC_CACHE).then((cache) => cache.addAll(OFFLINE_URLS))
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(OFFLINE_URLS)),
   );
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) => Promise.all(keys.filter((key) => !key.startsWith(VERSION)).map((key) => caches.delete(key))))
+    caches.keys().then((keys) => Promise.all(
+      keys
+        .filter((key) => !key.startsWith(VERSION))
+        .map((key) => caches.delete(key)),
+    )),
   );
   self.clients.claim();
 });
@@ -35,6 +42,6 @@ self.addEventListener('fetch', (event) => {
       const copy = response.clone();
       caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
       return response;
-    }))
+    })),
   );
 });

--- a/src/App/JobsService.php
+++ b/src/App/JobsService.php
@@ -29,6 +29,19 @@ class JobsService
         $this->jwt = new JwtService();
     }
 
+    /**
+     * @param array{
+     *     delivery_note_nr:string,
+     *     team_id:int,
+     *     starts_at:string,
+     *     ends_at:string,
+     *     timezone?:string,
+     *     phones?:array<int, string>,
+     *     location_city:string,
+     *     notes?:string
+     * } $payload
+     * @return array{job_id:int,public_job_url:string,caldav_event_uid:string}|WP_Error
+     */
     public function createJob(array $payload, int $authorId): array|WP_Error
     {
         global $wpdb;
@@ -72,6 +85,7 @@ class JobsService
         $wpdb->insert($wpdb->prefix . 'sg_jobs', $jobData);
         $jobId = (int) $wpdb->insert_id;
 
+        /** @var array<int, array<string, mixed>> $positions */
         foreach ($positions as $index => $position) {
             $wpdb->insert($wpdb->prefix . 'sg_job_positions', [
                 'job_id' => $jobId,
@@ -113,6 +127,9 @@ class JobsService
         ];
     }
 
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function markStatus(int $jobId, string $status, array $meta = []): bool|WP_Error
     {
         global $wpdb;
@@ -150,6 +167,9 @@ class JobsService
         return $this->markStatus($jobId, 'paid', ['actor' => 'system']);
     }
 
+    /**
+     * @return array<string, mixed>|WP_Error
+     */
     public function getJobById(int $jobId): array|WP_Error
     {
         global $wpdb;
@@ -165,6 +185,9 @@ class JobsService
         return $row;
     }
 
+    /**
+     * @param array<string, mixed> $meta
+     */
     private function logAudit(int $jobId, string $action, array $meta): void
     {
         global $wpdb;

--- a/src/App/Sync/CalDavWatcher.php
+++ b/src/App/Sync/CalDavWatcher.php
@@ -15,6 +15,8 @@ class CalDavWatcher
 
     public function pollForChanges(): void
     {
-        Logger::instance()->info('CalDAV watcher executed', []);
+        Logger::instance()->info('CalDAV watcher executed', [
+            'client' => get_class($this->client),
+        ]);
     }
 }

--- a/src/App/TeamsService.php
+++ b/src/App/TeamsService.php
@@ -8,12 +8,18 @@ use WP_Error;
 
 class TeamsService
 {
+    /**
+     * @return list<array<string, mixed>>
+     */
     public function listTeams(): array
     {
         global $wpdb;
         return $wpdb->get_results('SELECT * FROM ' . $wpdb->prefix . 'sg_teams ORDER BY name ASC', ARRAY_A);
     }
 
+    /**
+     * @return array<string, mixed>|WP_Error
+     */
     public function getTeam(int $teamId): array|WP_Error
     {
         global $wpdb;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -109,7 +109,7 @@ class Bootstrap
         }
     }
 
-    private function resolveMigrationClass(string $path): ?string
+    private function resolveMigrationClass(string $path): string
     {
         $file = pathinfo($path, PATHINFO_FILENAME);
         $normalized = str_replace(['_', '-'], ' ', $file);

--- a/src/Domain/Entity/Job.php
+++ b/src/Domain/Entity/Job.php
@@ -27,6 +27,7 @@ class Job
         private string $timezone,
         private ?string $caldavEventUid,
         private string $publicUrl,
+        /** @var list<JobPosition> */
         private array $positions,
         private ?string $notes
     ) {
@@ -97,7 +98,9 @@ class Job
         return $this->publicUrl;
     }
 
-    /** @return JobPosition[] */
+    /**
+     * @return list<JobPosition>
+     */
     public function positions(): array
     {
         return $this->positions;

--- a/src/Domain/Entity/JobPosition.php
+++ b/src/Domain/Entity/JobPosition.php
@@ -18,6 +18,9 @@ class JobPosition
     ) {
     }
 
+    /**
+     * @return array{bexio_position_id:int,article_no:string,title:string,description:string,qty:float,unit:string,work_type:string,sort:int}
+     */
     public function toArray(): array
     {
         return [

--- a/src/Domain/ValueObjects/PhoneList.php
+++ b/src/Domain/ValueObjects/PhoneList.php
@@ -17,6 +17,9 @@ class PhoneList
         $this->phones = array_values(array_filter(array_map([$this, 'normalise'], $phones)));
     }
 
+    /**
+     * @return list<string>
+     */
     public function toArray(): array
     {
         return $this->phones;

--- a/src/Http/Api/HealthController.php
+++ b/src/Http/Api/HealthController.php
@@ -27,6 +27,9 @@ class HealthController
         return current_user_can('manage_options');
     }
 
+    /**
+     * @param WP_REST_Request<array<string, mixed>> $request
+     */
     public function check(WP_REST_Request $request): WP_REST_Response
     {
         $errors = [];
@@ -143,7 +146,7 @@ class HealthController
     }
 
     /**
-     * @return array<int, array{name:string, principal:string, execution:string, blocker:string}>
+     * @return list<array{name:string, principal:string, execution:string, blocker:string}>
      */
     private function loadTeams(): array
     {

--- a/src/Http/Api/MagicLinkController.php
+++ b/src/Http/Api/MagicLinkController.php
@@ -6,7 +6,9 @@ namespace SGJobs\Http\Api;
 
 use SGJobs\App\JobsService;
 use SGJobs\Http\Middleware\Auth;
+use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 class MagicLinkController
@@ -38,7 +40,11 @@ class MagicLinkController
         });
     }
 
-    public function listJobs(WP_REST_Request $request)
+    /**
+     * @param WP_REST_Request<array<string, mixed>> $request
+     * @return array{jobs:array<array-key, mixed>}
+     */
+    public function listJobs(WP_REST_Request $request): array
     {
         // Simplified response placeholder
         return [
@@ -46,19 +52,23 @@ class MagicLinkController
         ];
     }
 
-    public function jobByToken(WP_REST_Request $request)
+    /**
+     * @param WP_REST_Request<array<string, mixed>> $request
+     * @return array<string, mixed>|WP_REST_Response
+     */
+    public function jobByToken(WP_REST_Request $request): array|WP_REST_Response
     {
         $token = $request['token'];
         $claims = $this->auth->validateInstallerToken($token);
-        if ($claims instanceof \WP_Error) {
+        if ($claims instanceof WP_Error) {
             return $this->auth->toRestError($claims);
         }
         $jobId = (int) ($claims['job_id'] ?? 0);
         if (! $jobId) {
-            return $this->auth->toRestError(new \WP_Error('sg_jobs_invalid_token', __('Token enthält keine Job-ID.', 'sg-jobs')));
+            return $this->auth->toRestError(new WP_Error('sg_jobs_invalid_token', __('Token enthält keine Job-ID.', 'sg-jobs')));
         }
         $job = $this->jobs->getJobById($jobId);
-        if ($job instanceof \WP_Error) {
+        if ($job instanceof WP_Error) {
             return $this->auth->toRestError($job);
         }
         return $job;

--- a/src/Http/Middleware/Auth.php
+++ b/src/Http/Middleware/Auth.php
@@ -11,6 +11,9 @@ use WP_REST_Response;
 
 class Auth
 {
+    /**
+     * @var array<string, mixed>|null
+     */
     private ?array $installerClaims = null;
 
     private JwtService $jwt;
@@ -45,17 +48,23 @@ class Auth
         return true;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function currentInstallerClaims(): array
     {
         return $this->installerClaims ?? [];
     }
 
+    /**
+     * @return array<string, mixed>|WP_Error
+     */
     public function validateInstallerToken(string $token): array|WP_Error
     {
         return $this->jwt->validateToken($token);
     }
 
-    public function toRestError(WP_Error $error)
+    public function toRestError(WP_Error $error): WP_REST_Response
     {
         return new WP_REST_Response([
             'error' => [

--- a/src/Infra/Bexio/BexioClient.php
+++ b/src/Infra/Bexio/BexioClient.php
@@ -33,6 +33,8 @@ class BexioClient
     }
 
     /**
+     * @param array<string, mixed> $query
+     * @return array<string, mixed>
      * @throws GuzzleException
      */
     public function get(string $path, array $query = []): array
@@ -60,6 +62,8 @@ class BexioClient
     }
 
     /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
      * @throws GuzzleException
      */
     public function post(string $path, array $payload): array

--- a/src/Infra/Bexio/BexioService.php
+++ b/src/Infra/Bexio/BexioService.php
@@ -14,14 +14,28 @@ class BexioService
     {
     }
 
+    /**
+     * @return array{
+     *     id:int,
+     *     document_nr:string,
+     *     customer_name:string,
+     *     delivery_address:array<string, mixed>,
+     *     phones:list<string>,
+     *     sales_order_nr:string|null
+     * }|WP_Error
+     */
     public function getDeliveryNoteByNumber(string $number): array|WP_Error
     {
         try {
             $notes = $this->client->get('/kb_delivery_notes', ['document_nr' => $number]);
-            if (! $notes) {
+            if (! is_array($notes) || $notes === []) {
                 return new WP_Error('sg_jobs_delivery_note_missing', __('Delivery note not found in bexio.', 'sg-jobs'));
             }
-            $note = $notes[0];
+            $note = $notes[array_key_first($notes)];
+            if (! is_array($note)) {
+                return new WP_Error('sg_jobs_delivery_note_missing', __('Delivery note not found in bexio.', 'sg-jobs'));
+            }
+            /** @var array<string, mixed> $note */
             return [
                 'id' => (int) $note['id'],
                 'document_nr' => $note['document_nr'],
@@ -35,10 +49,31 @@ class BexioService
         }
     }
 
+    /**
+     * @return list<array{
+     *     bexio_position_id:int,
+     *     article_no:string,
+     *     title:string,
+     *     description:string,
+     *     qty:float,
+     *     unit:string
+     * }>|WP_Error
+     */
     public function getDeliveryNotePositions(int $deliveryNoteId): array|WP_Error
     {
         try {
             $positions = $this->client->get(sprintf('/kb_delivery_notes/%d/positions', $deliveryNoteId));
+            if (! is_array($positions)) {
+                return [];
+            }
+
+            $cleanPositions = [];
+            foreach ($positions as $position) {
+                if (is_array($position)) {
+                    $cleanPositions[] = $position;
+                }
+            }
+
             return array_map(static function (array $position): array {
                 return [
                     'bexio_position_id' => (int) $position['id'],
@@ -48,7 +83,7 @@ class BexioService
                     'qty' => (float) $position['amount'],
                     'unit' => (string) $position['unit_name'],
                 ];
-            }, $positions);
+            }, $cleanPositions);
         } catch (GuzzleException $exception) {
             return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
         }
@@ -73,16 +108,24 @@ class BexioService
 
         try {
             $invoices = $this->client->get('/kb_invoices', ['document_nr' => $salesOrder]);
-            if (! $invoices) {
+            if (! is_array($invoices) || $invoices === []) {
                 return false;
             }
-            $invoice = $invoices[0];
+            $invoice = $invoices[array_key_first($invoices)];
+            if (! is_array($invoice)) {
+                return false;
+            }
+            /** @var array<string, mixed> $invoice */
             return isset($invoice['is_paid']) && (bool) $invoice['is_paid'];
         } catch (GuzzleException $exception) {
             return new WP_Error('sg_jobs_bexio_error', $exception->getMessage());
         }
     }
 
+    /**
+     * @param array<string, mixed> $note
+     * @return list<string>
+     */
     private function extractPhones(array $note): array
     {
         $phones = [];

--- a/src/Infra/CalDAV/CalDAVClient.php
+++ b/src/Infra/CalDAV/CalDAVClient.php
@@ -23,6 +23,9 @@ class CalDAVClient
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function request(string $method, string $path, array $options = []): string
     {
         $response = $this->client->request($method, $path, $options);

--- a/src/Infra/Logging/Logger.php
+++ b/src/Infra/Logging/Logger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SGJobs\Infra\Logging;
 
 use Psr\Log\AbstractLogger;
+use Stringable;
 
 class Logger extends AbstractLogger
 {
@@ -19,6 +20,11 @@ class Logger extends AbstractLogger
         return self::$instance;
     }
 
+    /**
+     * @param string $level
+     * @param string|Stringable $message
+     * @param array<string, mixed> $context
+     */
     public function log($level, $message, array $context = []): void
     {
         $entry = sprintf('[SG Jobs][%s] %s %s', strtoupper((string) $level), $message, wp_json_encode($context));

--- a/src/Infra/Queue/QueueService.php
+++ b/src/Infra/Queue/QueueService.php
@@ -6,6 +6,9 @@ namespace SGJobs\Infra\Queue;
 
 class QueueService
 {
+    /**
+     * @param array<string, mixed> $args
+     */
     public function dispatch(string $hook, array $args = [], int $delay = 0): void
     {
         if ($delay > 0) {

--- a/src/Infra/Security/JwtService.php
+++ b/src/Infra/Security/JwtService.php
@@ -71,6 +71,9 @@ class JwtService
         $this->expiryDays = ($expiryDays && $expiryDays > 0) ? $expiryDays : 14;
     }
 
+    /**
+     * @param array<string, mixed> $claims
+     */
     public function createToken(array $claims): string
     {
         $payload = array_merge($claims, [
@@ -82,6 +85,9 @@ class JwtService
         return JWT::encode($payload, $this->secret, 'HS256');
     }
 
+    /**
+     * @return array<string, mixed>|WP_Error
+     */
     public function validateToken(string $token): array|WP_Error
     {
         try {

--- a/src/Ui/Board/assets/board.tsx
+++ b/src/Ui/Board/assets/board.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -14,11 +14,11 @@ type JobEvent = {
   status: string;
 };
 
-const BoardApp: React.FC = () => {
+function BoardApp(): JSX.Element {
   const [events, setEvents] = useState<JobEvent[]>([]);
 
   useEffect(() => {
-    fetch('/wp-json/sgjobs/v1/jobs?date=' + dayjs().format('YYYY-MM-DD'))
+    fetch(`/wp-json/sgjobs/v1/jobs?date=${dayjs().format('YYYY-MM-DD')}`)
       .then((res) => res.json())
       .then((data) => setEvents(data.jobs || []))
       .catch((err) => console.error('Failed loading jobs', err));
@@ -39,7 +39,7 @@ const BoardApp: React.FC = () => {
       />
     </div>
   );
-};
+}
 
 const container = document.getElementById('sg-jobs-board');
 if (container) {

--- a/src/Ui/JobSheet/assets/jobsheet.tsx
+++ b/src/Ui/JobSheet/assets/jobsheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 type Job = {
@@ -9,7 +9,7 @@ type Job = {
   notes: string;
 };
 
-const JobSheet: React.FC = () => {
+function JobSheet(): JSX.Element {
   const [job, setJob] = useState<Job | null>(null);
   const [comment, setComment] = useState('');
   const [status, setStatus] = useState('');
@@ -41,7 +41,11 @@ const JobSheet: React.FC = () => {
 
   return (
     <div className="jobsheet">
-      <h1>✅ Lieferschein {job.delivery_note_nr}</h1>
+      <h1>
+        ✅ Lieferschein
+        {' '}
+        <span className="delivery-note-number">{job.delivery_note_nr}</span>
+      </h1>
       <h2>{job.customer_name}</h2>
       <div className="phones">
         {job.phones.map((phone) => (
@@ -57,10 +61,12 @@ const JobSheet: React.FC = () => {
       {status === 'done' && <p className="status">Danke! Status aktualisiert.</p>}
     </div>
   );
-};
+}
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/wp-content/plugins/sg-jobs/public/sw.js').catch(console.error);
+  navigator.serviceWorker
+    .register('/wp-content/plugins/sg-jobs/public/sw.js')
+    .catch((error) => console.error('Service worker registration failed', error));
 }
 
 const container = document.getElementById('sg-jobs-sheet');

--- a/src/Util/Formatting.php
+++ b/src/Util/Formatting.php
@@ -43,6 +43,9 @@ class Formatting
         );
     }
 
+    /**
+     * @param array<string, mixed> $row
+     */
     public static function jobFromRow(array $row): Job
     {
         global $wpdb;
@@ -57,9 +60,14 @@ class Formatting
         $phones = new PhoneList($phonesArray);
         $timeRange = new TimeRange($start, $end);
         $address = new Address($row['address_line'] ?? '', '', $row['location_city'], 'CH');
+        $rawPositions = $row['positions'] ?? [];
+        if (! is_array($rawPositions)) {
+            $rawPositions = [];
+        }
+
         $positions = array_map(static function (array $pos): JobPosition {
             return new JobPosition($pos['bexio_position_id'], $pos['article_no'], $pos['title'], $pos['description'], (float) $pos['qty'], $pos['unit'], $pos['work_type'], (int) $pos['sort']);
-        }, $row['positions'] ?? []);
+        }, $rawPositions);
 
         return new Job(
             (int) $row['id'],

--- a/stubs/wordpress.php
+++ b/stubs/wordpress.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    define('ABSPATH', '/var/www/html/');
+}
+
+if (! defined('ARRAY_A')) {
+    define('ARRAY_A', 'ARRAY_A');
+}
+
+if (! defined('ARRAY_N')) {
+    define('ARRAY_N', 'ARRAY_N');
+}
+
+if (! defined('OBJECT')) {
+    define('OBJECT', 'OBJECT');
+}
+
+if (! defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+if (! defined('SGJOBS_PLUGIN_FILE')) {
+    define('SGJOBS_PLUGIN_FILE', __FILE__);
+}
+
+if (! function_exists('as_schedule_single_action')) {
+    /**
+     * @param array<string, mixed> $args
+     */
+    function as_schedule_single_action(int $timestamp, string $hook, array $args = [], string $group = ''): int
+    {
+        return 0;
+    }
+}
+
+if (! function_exists('as_enqueue_async_action')) {
+    /**
+     * @param array<string, mixed> $args
+     */
+    function as_enqueue_async_action(string $hook, array $args = [], string $group = ''): int
+    {
+        return 0;
+    }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": [
+    "src/Ui/**/*.ts",
+    "src/Ui/**/*.tsx",
+    "public/**/*.js"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated PHPStan configuration with WordPress bootstrap stubs and tighten PHP array typing across services
- require missing runtime tooling (psr/log, WordPress stubs) and tweak ESLint configuration/TypeScript project files for linting support
- convert the board and job sheet React components plus the service worker to the expected linting style and dependency set

## Testing
- composer analyse
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df42b31d648322b6b575a7a779acb3