### PR TITLE
Normalize board team URLs

### DIFF
--- a/src/Ui/Board/BoardController.php
+++ b/src/Ui/Board/BoardController.php
@@ -64,16 +64,20 @@ class BoardController
                 $team['principal'] = $team['caldav_principal'];
             }
 
-            if (! array_key_exists('execution', $team)) {
-                $team['execution'] = null;
+            foreach (['execution', 'blocker'] as $key) {
+                if (! empty($team[$key]) && is_string($team[$key])) {
+                    $team[$key] = rtrim($team[$key], '/') . '/';
+                }
             }
 
-            if (! array_key_exists('principal', $team)) {
-                $team['principal'] = null;
+            if (! empty($team['principal']) && is_string($team['principal'])) {
+                $team['principal'] = rtrim($team['principal'], '/') . '/';
             }
 
-            if (! array_key_exists('blocker', $team)) {
-                $team['blocker'] = null;
+            foreach (['execution', 'principal', 'blocker'] as $key) {
+                if (! array_key_exists($key, $team)) {
+                    $team[$key] = null;
+                }
             }
         }
         unset($team);


### PR DESCRIPTION
## Summary
- ensure legacy team calendar fields are normalized to execution endpoints
- append trailing slashes to CalDAV URLs so the board receives canonical endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb2a041e4832295f3578713b2712f