### PR TITLE
Gracefully handle missing Composer autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ SG Jobs bridges bexio delivery notes with a scheduling cockpit and mobile job ex
 7. **Healthcheck ausführen** – Nutze den Healthcheck im Admin („Test CalDAV/Bexio“), um Anmelde- und Freigabeprobleme zu erkennen. Ergebnisse werden farblich nach HTTP-Status codiert.
 8. **Dispo-Board testen** – Rufe das Dispo-Board mit dem Shortcode `[sg_jobs_board]` auf (erfordert Capability `sgjobs_manage`) und führe einen Testlauf durch. Prüfe außerdem das Installer-Board über `[sg_jobs_mine]`.
 
+## Deployment package
+
+Before uploading the plugin through the WordPress admin, build a distributable package that already contains Composer dependencies:
+
+```bash
+composer install --no-dev --optimize-autoloader
+npm install
+npm run build
+zip -r sg-jobs.zip . -x 'node_modules/*' 'tests/*'
+```
+
+Upload the generated `sg-jobs.zip` via **Plugins → Install → Upload Plugin** or copy the directory (including the `vendor/` folder) to `wp-content/plugins/sg-jobs`.
+
 ## Development setup
 
 ```bash

--- a/sg-jobs.php
+++ b/sg-jobs.php
@@ -15,7 +15,28 @@ if (! defined('ABSPATH')) {
     exit;
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+$autoload = __DIR__ . '/vendor/autoload.php';
+
+if (! file_exists($autoload)) {
+    $notice = static function (): void {
+        echo '<div class="notice notice-error"><p>';
+        echo esc_html__(
+            'SG Jobs requires Composer dependencies. Run "composer install --no-dev" before activating the plugin, '
+            . 'or upload a release package that already contains the vendor directory.',
+            'sg-jobs'
+        );
+        echo '</p></div>';
+    };
+
+    if (function_exists('add_action')) {
+        add_action('admin_notices', $notice);
+        add_action('network_admin_notices', $notice);
+    }
+
+    return;
+}
+
+require_once $autoload;
 
 if (! defined('SGJOBS_MAIN_FILE')) {
     define('SGJOBS_MAIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- prevent fatal errors by checking for the Composer autoloader and surfacing an admin notice when dependencies are missing
- document how to build a deployable archive that already contains vendor dependencies before uploading to WordPress

## Testing
- php -l sg-jobs.php

------
https://chatgpt.com/codex/tasks/task_e_68e3e9dfac5c8322ad533c6daa58c7cd