### PR TITLE
Fix shortcode asset loading and normalize teams

### DIFF
--- a/sg-jobs.php
+++ b/sg-jobs.php
@@ -50,6 +50,203 @@ if (! defined('SGJOBS_PLUGIN_FILE')) {
     define('SGJOBS_PLUGIN_FILE', SGJOBS_MAIN_FILE);
 }
 
+if (! function_exists('sgj_normalize_team_path')) {
+    function sgj_normalize_team_path(?string $value): string
+    {
+        $value = trim((string) $value);
+        if ($value === '') {
+            return '';
+        }
+
+        return rtrim($value, '/') . '/';
+    }
+}
+
+if (! function_exists('sgj_normalize_teams_data')) {
+    function sgj_normalize_teams_data(mixed $teams): array
+    {
+        if (is_string($teams)) {
+            $decoded = json_decode($teams, true);
+            $teams = is_array($decoded) ? $decoded : [];
+        }
+
+        if (! is_array($teams)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($teams as $team) {
+            if (! is_array($team)) {
+                $team = [];
+            }
+
+            $name = sanitize_text_field((string) ($team['name'] ?? ''));
+            $principal = sanitize_text_field((string) ($team['principal'] ?? ($team['caldav_principal'] ?? '')));
+            $execution = sanitize_text_field((string) ($team['execution'] ?? ($team['execution_path'] ?? ($team['calendar'] ?? ($team['exec'] ?? '')))));
+            $blocker = sanitize_text_field((string) ($team['blocker'] ?? ($team['blocker_path'] ?? '')));
+
+            $principal = sgj_normalize_team_path($principal);
+            $execution = sgj_normalize_team_path($execution);
+            $blocker = sgj_normalize_team_path($blocker);
+
+            if ($name === '' && $principal === '' && $execution === '' && $blocker === '') {
+                continue;
+            }
+
+            $normalized[] = [
+                'name' => $name,
+                'principal' => $principal,
+                'execution' => $execution,
+                'blocker' => $blocker,
+            ];
+        }
+
+        return array_values($normalized);
+    }
+}
+
+if (! function_exists('sgj_get_normalized_teams')) {
+    function sgj_get_normalized_teams(): array
+    {
+        $raw = get_option('sg_jobs_teams', []);
+        $normalized = sgj_normalize_teams_data($raw);
+
+        $rawComparable = is_array($raw) ? array_values($raw) : [];
+        if (serialize($normalized) !== serialize($rawComparable)) {
+            update_option('sg_jobs_teams', $normalized, false);
+        }
+
+        return $normalized;
+    }
+}
+
+if (! function_exists('sgj_resolve_asset')) {
+    /**
+     * @return array{js:string,css:array<int,string>}
+     */
+    function sgj_resolve_asset(string $entry): array
+    {
+        $basePath = plugin_dir_path(SGJOBS_MAIN_FILE) . 'dist/';
+        $baseUrl = plugin_dir_url(SGJOBS_MAIN_FILE) . 'dist/';
+        $manifestFile = $basePath . 'manifest.json';
+
+        static $manifest = null;
+        if ($manifest === null) {
+            $manifest = [];
+            if (file_exists($manifestFile)) {
+                $json = json_decode((string) file_get_contents($manifestFile), true);
+                if (is_array($json)) {
+                    $manifest = $json;
+                }
+            }
+        }
+
+        if (isset($manifest[$entry]) && is_array($manifest[$entry])) {
+            $info = $manifest[$entry];
+            $css = [];
+            if (! empty($info['css']) && is_array($info['css'])) {
+                foreach ($info['css'] as $style) {
+                    $css[] = $baseUrl . ltrim((string) $style, '/');
+                }
+            }
+
+            return [
+                'js' => $baseUrl . ltrim((string) $info['file'], '/'),
+                'css' => $css,
+            ];
+        }
+
+        $asset = [
+            'js' => $baseUrl . $entry,
+            'css' => [],
+        ];
+
+        $entryBase = preg_replace('/\.js$/', '', $entry);
+        $directCss = $basePath . $entryBase . '.css';
+        if ($entryBase && file_exists($directCss)) {
+            $asset['css'][] = $baseUrl . $entryBase . '.css';
+        }
+
+        $nestedCssPath = $basePath . $entryBase . '/' . $entryBase . '.css';
+        if ($entryBase && file_exists($nestedCssPath)) {
+            $asset['css'][] = $baseUrl . $entryBase . '/' . $entryBase . '.css';
+        }
+
+        return $asset;
+    }
+}
+
+if (! function_exists('sgj_register_front_assets')) {
+    function sgj_register_front_assets(): void
+    {
+        $board = sgj_resolve_asset('board.js');
+        if (! wp_script_is('sgjobs-board', 'registered')) {
+            wp_register_script('sgjobs-board', $board['js'], [], SGJOBS_VERSION, true);
+        }
+        foreach ($board['css'] as $index => $href) {
+            $handle = 'sgjobs-board-css-' . $index;
+            if (! wp_style_is($handle, 'registered')) {
+                wp_register_style($handle, $href, [], SGJOBS_VERSION);
+            }
+        }
+
+        $sheet = sgj_resolve_asset('jobsheet.js');
+        if (! wp_script_is('sgjobs-jobsheet', 'registered')) {
+            wp_register_script('sgjobs-jobsheet', $sheet['js'], [], SGJOBS_VERSION, true);
+        }
+        foreach ($sheet['css'] as $index => $href) {
+            $handle = 'sgjobs-jobsheet-css-' . $index;
+            if (! wp_style_is($handle, 'registered')) {
+                wp_register_style($handle, $href, [], SGJOBS_VERSION);
+            }
+        }
+    }
+
+    add_action('wp_enqueue_scripts', 'sgj_register_front_assets');
+}
+
+if (! function_exists('sgj_enqueue_style_prefix')) {
+    function sgj_enqueue_style_prefix(string $prefix): void
+    {
+        $styles = wp_styles();
+        if (! $styles) {
+            return;
+        }
+
+        foreach ($styles->registered as $handle => $style) {
+            if (str_starts_with($handle, $prefix)) {
+                wp_enqueue_style($handle);
+            }
+        }
+    }
+}
+
+if (! function_exists('sgj_mark_module_scripts')) {
+    function sgj_mark_module_scripts(string $tag, string $handle, string $src): string
+    {
+        if (in_array($handle, ['sgjobs-board', 'sgjobs-jobsheet'], true) && ! str_contains($tag, 'type="module"')) {
+            $tag = str_replace('<script ', '<script type="module" ', $tag);
+        }
+
+        return $tag;
+    }
+
+    add_filter('script_loader_tag', 'sgj_mark_module_scripts', 10, 3);
+}
+
+add_action('init', static function (): void {
+    add_shortcode('sg_jobs_ping', static fn (): string => '<div style="padding:8px;background:#e8f5e9;border:1px solid #2e7d32">SG-Jobs Shortcode OK</div>');
+
+    add_shortcode('sg_jobs_health', static function (): string {
+        $status = [
+            'jwt' => trim((string) get_option('sg_jobs_jwt_secret', '')) !== '',
+            'teams' => count(sgj_get_normalized_teams()) > 0,
+        ];
+
+        return '<pre>' . esc_html(print_r($status, true)) . '</pre>';
+    });
+});
+
 use SGJobs\Bootstrap;
 
 $bootstrap = Bootstrap::instance();

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SGJobs\Admin;
 
+use function sgj_get_normalized_teams;
+use function sgj_normalize_teams_data;
+
 class SettingsPage
 {
     public function register(): void
@@ -202,6 +205,8 @@ class SettingsPage
             ];
         }
 
+        $teams = sgj_normalize_teams_data($teams);
+
         $count = count($teams);
         if ($count > 0) {
             add_settings_error(
@@ -220,28 +225,6 @@ class SettingsPage
      */
     private function getNormalizedTeams(): array
     {
-        $teams = get_option('sg_jobs_teams', []);
-        if (is_string($teams)) {
-            $decoded = json_decode($teams, true);
-            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
-                $teams = $decoded;
-            }
-        }
-
-        if (! is_array($teams)) {
-            return [];
-        }
-
-        $normalized = [];
-        foreach ($teams as $team) {
-            $normalized[] = [
-                'name' => isset($team['name']) ? (string) $team['name'] : '',
-                'principal' => isset($team['principal']) ? (string) $team['principal'] : (isset($team['caldav_principal']) ? (string) $team['caldav_principal'] : ''),
-                'execution' => isset($team['execution']) ? (string) $team['execution'] : (isset($team['execution_path']) ? (string) $team['execution_path'] : (isset($team['calendar']) ? (string) $team['calendar'] : (isset($team['exec']) ? (string) $team['exec'] : ''))),
-                'blocker' => isset($team['blocker']) ? (string) $team['blocker'] : (isset($team['blocker_path']) ? (string) $team['blocker_path'] : ''),
-            ];
-        }
-
-        return $normalized;
+        return sgj_get_normalized_teams();
     }
 }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -14,6 +14,7 @@ use SGJobs\Infra\Security\JwtService;
 use SGJobs\Ui\Board\BoardController;
 use SGJobs\Ui\JobSheet\JobSheetController;
 use WP_Error;
+use function sgj_normalize_teams_data;
 
 class Bootstrap
 {
@@ -129,12 +130,12 @@ class Bootstrap
 
     private function migrateTeamsOption(): void
     {
-        $value = get_option('sg_jobs_teams');
-        if (is_string($value)) {
-            $decoded = json_decode($value, true);
-            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
-                update_option('sg_jobs_teams', $decoded, false);
-            }
+        $raw = get_option('sg_jobs_teams', null);
+        $normalized = sgj_normalize_teams_data($raw);
+        $rawComparable = is_array($raw) ? array_values($raw) : [];
+
+        if (serialize($normalized) !== serialize($rawComparable)) {
+            update_option('sg_jobs_teams', $normalized, false);
         }
     }
 

--- a/src/Http/Api/HealthController.php
+++ b/src/Http/Api/HealthController.php
@@ -10,6 +10,7 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use function sgj_get_normalized_teams;
 
 class HealthController
 {
@@ -176,33 +177,7 @@ class HealthController
      */
     private function loadTeams(): array
     {
-        $teams = get_option('sg_jobs_teams', []);
-        if (is_string($teams)) {
-            $decoded = json_decode($teams, true);
-            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
-                $teams = $decoded;
-            }
-        }
-
-        if (! is_array($teams)) {
-            return [];
-        }
-
-        $normalized = [];
-        foreach ($teams as $team) {
-            if (! is_array($team)) {
-                continue;
-            }
-
-            $normalized[] = [
-                'name' => isset($team['name']) ? (string) $team['name'] : '',
-                'principal' => isset($team['principal']) ? (string) $team['principal'] : (isset($team['caldav_principal']) ? (string) $team['caldav_principal'] : ''),
-                'execution' => isset($team['execution']) ? (string) $team['execution'] : (isset($team['execution_path']) ? (string) $team['execution_path'] : (isset($team['calendar']) ? (string) $team['calendar'] : (isset($team['exec']) ? (string) $team['exec'] : ''))),
-                'blocker' => isset($team['blocker']) ? (string) $team['blocker'] : (isset($team['blocker_path']) ? (string) $team['blocker_path'] : ''),
-            ];
-        }
-
-        return $normalized;
+        return sgj_get_normalized_teams();
     }
 
     private function resolveCalendarUrl(string $baseUrl, string $path): string

--- a/src/Ui/Board/BoardController.php
+++ b/src/Ui/Board/BoardController.php
@@ -4,88 +4,22 @@ declare(strict_types=1);
 
 namespace SGJobs\Ui\Board;
 
+use function sgj_enqueue_style_prefix;
+use function sgj_get_normalized_teams;
+
 class BoardController
 {
     public function register(): void
     {
         add_shortcode('sg_jobs_board', [$this, 'renderBoard']);
-        add_action('wp_enqueue_scripts', [$this, 'registerBoardAssets']);
-    }
-
-    public function registerBoardAssets(): void
-    {
-        $mainFile = defined('SGJOBS_MAIN_FILE') ? SGJOBS_MAIN_FILE : (defined('SGJOBS_PLUGIN_FILE') ? SGJOBS_PLUGIN_FILE : __FILE__);
-        $version = defined('SGJOBS_VERSION') ? SGJOBS_VERSION : 'dev';
-
-        $baseUrl = plugin_dir_url($mainFile) . 'dist/';
-        $basePath = plugin_dir_path($mainFile) . 'dist/';
-
-        wp_register_script(
-            'sgjobs-board',
-            $baseUrl . 'board.js',
-            [],
-            $version,
-            true
-        );
-
-        $stylesheetPath = $basePath . 'board/board.css';
-        if (file_exists($stylesheetPath)) {
-            wp_register_style(
-                'sgjobs-board',
-                $baseUrl . 'board/board.css',
-                [],
-                $version
-            );
-        }
     }
 
     public function renderBoard(): string
     {
-        $teams = get_option('sg_jobs_teams', []);
-        if (is_string($teams)) {
-            $decoded = json_decode($teams, true);
-            $teams = is_array($decoded) ? $decoded : [];
-        }
-
-        if (! is_array($teams)) {
-            $teams = [];
-        }
-
-        foreach ($teams as &$team) {
-            if (! is_array($team)) {
-                $team = [];
-            }
-
-            if (! isset($team['execution']) && isset($team['calendar'])) {
-                $team['execution'] = $team['calendar'];
-            }
-
-            if (! isset($team['principal']) && isset($team['caldav_principal'])) {
-                $team['principal'] = $team['caldav_principal'];
-            }
-
-            foreach (['execution', 'blocker'] as $key) {
-                if (! empty($team[$key]) && is_string($team[$key])) {
-                    $team[$key] = rtrim($team[$key], '/') . '/';
-                }
-            }
-
-            if (! empty($team['principal']) && is_string($team['principal'])) {
-                $team['principal'] = rtrim($team['principal'], '/') . '/';
-            }
-
-            foreach (['execution', 'principal', 'blocker'] as $key) {
-                if (! array_key_exists($key, $team)) {
-                    $team[$key] = null;
-                }
-            }
-        }
-        unset($team);
+        $teams = sgj_get_normalized_teams();
 
         wp_enqueue_script('sgjobs-board');
-        if (wp_style_is('sgjobs-board', 'registered')) {
-            wp_enqueue_style('sgjobs-board');
-        }
+        sgj_enqueue_style_prefix('sgjobs-board-css-');
 
         wp_localize_script('sgjobs-board', 'SGJOBS_BOARD', [
             'teams' => $teams,
@@ -94,6 +28,6 @@ class BoardController
             'version' => defined('SGJOBS_VERSION') ? SGJOBS_VERSION : 'dev',
         ]);
 
-        return '<div id="sgjobs-board-root"></div>';
+        return '<div id="sg-jobs-board"></div>';
     }
 }

--- a/src/Ui/JobSheet/JobSheetController.php
+++ b/src/Ui/JobSheet/JobSheetController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SGJobs\Ui\JobSheet;
 
+use function sgj_enqueue_style_prefix;
+
 class JobSheetController
 {
     public function register(): void
@@ -26,8 +28,9 @@ class JobSheetController
 
     public function renderList(): string
     {
-        wp_enqueue_script('sg-jobs-sheet', plugins_url('dist/jobsheet.js', SGJOBS_PLUGIN_FILE), [], '0.1.0', true);
-        wp_enqueue_style('sg-jobs-sheet', plugins_url('dist/jobsheet.css', SGJOBS_PLUGIN_FILE), [], '0.1.0');
+        wp_enqueue_script('sgjobs-jobsheet');
+        sgj_enqueue_style_prefix('sgjobs-jobsheet-css-');
+
         return '<div id="sg-jobs-sheet"></div>';
     }
 


### PR DESCRIPTION
## Summary
- add helper utilities to resolve Vite assets, enqueue module scripts, register diagnostic shortcodes, and normalize stored team data
- update the board and job sheet shortcodes to rely on the registered assets, use the normalized team configuration, and render the correct mount points
- normalize team data throughout the admin settings, bootstrap migration, and health endpoint so legacy keys are migrated and paths gain trailing slashes

## Testing
- composer analyse *(fails: phpstan binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e401b6f684832280085047e331b190